### PR TITLE
If a cluster launch fails, allow a user to request another cluster

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -323,8 +323,14 @@ func (m *clusterManager) LaunchClusterForUser(req *ClusterRequest) (string, erro
 				log.Printf("user %q cluster is already up", user)
 				return "your cluster is already running, see your credentials again with the 'auth' command", nil
 			}
-			log.Printf("user %q cluster has no credentials yet", user)
-			return "", fmt.Errorf("you have already requested a cluster and it should be ready in ~ %d minutes", m.estimateCompletion(existing.RequestedAt)/time.Minute)
+			if len(cluster.Failure) == 0 {
+				log.Printf("user %q cluster has no credentials yet", user)
+				return "", fmt.Errorf("you have already requested a cluster and it should be ready in ~ %d minutes", m.estimateCompletion(existing.RequestedAt)/time.Minute)
+			}
+
+			log.Printf("user %q cluster failed, allowing them to request another", user)
+			delete(m.clusters, existing.Cluster)
+			delete(m.requests, user)
 		}
 	}
 	req.RequestedAt = time.Now()

--- a/slack.go
+++ b/slack.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -209,9 +210,13 @@ type slackResponse struct {
 }
 
 func isRetriable(err error) bool {
-	if err == nil {
+	// there are several conditions that result from closing the connection on our side
+	switch {
+	case err == nil,
+		err == io.EOF,
+		strings.Contains(err.Error(), "use of closed network connection"):
 		return true
+	default:
+		return false
 	}
-	// if we timeout and close the connection
-	return strings.Contains(err.Error(), "use of closed network connection")
 }


### PR DESCRIPTION
It's only fair.