### PR TITLE
Add another failure condition - partial deserialization

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -216,6 +216,10 @@ func isRetriable(err error) bool {
 		err == io.EOF,
 		strings.Contains(err.Error(), "use of closed network connection"):
 		return true
+	case strings.Contains(err.Error(), "cannot unmarshal object into Go struct field Message.user of type string"):
+		// this could be a legitimate error, so log it to ensure we can debug
+		log.Printf("warning: Ignoring serialization error and continuing: %v", err)
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
The last read after a close can sometimes return an empty / incomplete
object, in which case we get an error about serialization. This *could*
be an error, so we at least log it before retrying.