### PR TITLE
Wait longer for cluster to start, and display password snippet

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -54,8 +54,9 @@ type Cluster struct {
 
 	ReleaseImage string
 
-	Credentials string
-	Failure     string
+	Credentials     string
+	PasswordSnippet string
+	Failure         string
 
 	RequestedBy      string
 	RequestedChannel string


### PR DESCRIPTION
Wait 20m instead of 15m for start. Also grab the last two lines of
cluster setup output and print them in the message.