### PR TITLE
Support lookup of stable versions by x.y syntax

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -34,7 +34,7 @@ func (b *Bot) Start(manager JobManager) error {
 
 	slack.Command("launch <image_or_version_or_pr> <options>", &slacker.CommandDefinition{
 		Description: fmt.Sprintf(
-			"Launch an OpenShift cluster using a known image, version, or PR. You may omit both arguments. Use `nightly` for the latest OCP build, `ci` for the the latest CI build, `version` for a version listed on https://openshift-release.svc.ci.openshift.org, a stream name (4.1.0-0.ci, 4.1.0-0.nightly, etc), `<org>/<repo>#<pr>` to launch from a PR, or an image for the first argument. Options is a comma-delimited list of variations including platform (%s).",
+			"Launch an OpenShift cluster using a known image, version, or PR. You may omit both arguments. Use `nightly` for the latest OCP build, `ci` for the the latest CI build, provide a version directly from any listed on https://openshift-release.svc.ci.openshift.org, a stream name (4.1.0-0.ci, 4.1.0-0.nightly, etc), a major/minor `X.Y` to load the latest stable version for that version (`4.1`), `<org>/<repo>#<pr>` to launch from a PR, or an image for the first argument. Options is a comma-delimited list of variations including platform (%s).",
 			strings.Join(codeSlice(supportedPlatforms), ", "),
 		),
 		Example: "launch openshift/origin#49563 gcp",


### PR DESCRIPTION
Requires a stable version tagged into a stream.