### PR TITLE
Allow upgrades to PRs

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ func main() {
 }
 
 func run() error {
+	emptyFlags := flag.NewFlagSet("empty", flag.ContinueOnError)
+	klog.InitFlags(emptyFlags)
 	opt := &options{
 		GithubEndpoint: "https://api.github.com",
 	}
@@ -42,7 +44,7 @@ func run() error {
 	pflag.StringVar(&opt.JobConfigPath, "job-config", opt.JobConfigPath, "A config file containing the jobs to run against releases.")
 	pflag.StringVar(&opt.GithubEndpoint, "github-endpoint", opt.GithubEndpoint, "An optional proxy for connecting to github.")
 	pflag.StringVar(&opt.ForcePROwner, "force-pr-owner", opt.ForcePROwner, "Make the supplied user the owner of all PRs for access control purposes.")
-	pflag.CommandLine.AddGoFlag(flag.Lookup("v"))
+	pflag.CommandLine.AddGoFlag(emptyFlags.Lookup("v"))
 	pflag.Parse()
 	klog.SetOutput(os.Stderr)
 

--- a/manager.go
+++ b/manager.go
@@ -863,8 +863,8 @@ func (m *jobManager) resolveToJob(req *JobRequest) (*Job, error) {
 
 	// TODO: this should be possible but requires some thought, disable for now
 	// (mainly we need two namespaces and jobs to build in)
-	if job.UpgradeRefs != nil || (job.InstallRefs != nil && job.Mode == "upgrade") {
-		return nil, fmt.Errorf("upgrading to a PR build is not supported at this time")
+	if job.Mode == "upgrade" && job.InstallRefs != nil {
+		return nil, fmt.Errorf("upgrading is not supported from a PR, only to one")
 	}
 
 	return job, nil


### PR DESCRIPTION
Allow a PR to be specified as an upgrade target. Upgrade target is
easier than install target due to how ci-operator initializes its
content (we can't fake release latest). Also fix a klog error where
the v flag was not being honored.