### PR TITLE
Change how we calculate launched clusters, wait longer

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -951,7 +951,7 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 
 		launchedClusters := 0
 		for _, job := range m.jobs {
-			if job != nil && job.Mode == "launch" && !job.Complete {
+			if job != nil && job.Mode == "launch" && !job.Complete && len(job.Failure) == 0 {
 				launchedClusters++
 			}
 		}

--- a/prow.go
+++ b/prow.go
@@ -537,7 +537,7 @@ func waitForClusterReachable(kubeconfig string) error {
 		return err
 	}
 
-	return wait.PollImmediate(15*time.Second, 20*time.Minute, func() (bool, error) {
+	return wait.PollImmediate(15*time.Second, 30*time.Minute, func() (bool, error) {
 		_, err := client.Core().Namespaces().Get("openshift-apiserver", metav1.GetOptions{})
 		if err == nil {
 			return true, nil


### PR DESCRIPTION
Clusters reporting an error can be excluded from quota for now.