### PR TITLE
Revert changes to detect namespace deletion, races with creation

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -396,7 +396,7 @@ func (m *jobManager) launchJob(job *Job) error {
 			if !errors.IsNotFound(err) {
 				return false, err
 			}
-			if seen || errorAppliesToResource(err, "namespaces") {
+			if seen {
 				return false, fmt.Errorf("cluster has already been torn down")
 			}
 			return false, nil
@@ -426,7 +426,7 @@ func (m *jobManager) launchJob(job *Job) error {
 				lastErr = err
 				return false, err
 			}
-			if seen || errorAppliesToResource(err, "namespaces") {
+			if seen {
 				return false, fmt.Errorf("cluster has already been torn down")
 			}
 			return false, nil


### PR DESCRIPTION
The namespace could be waiting for creation while polling for pods.
Instead, we need to rely on the prow job and that is too complicated
a change.