### PR TITLE
During setup, attempt to set the `BRANCH` variable

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -720,6 +720,9 @@ func (m *jobManager) LookupImageOrVersion(imageOrVersion string) (string, error)
 	if len(installVersion) == 0 {
 		return fmt.Sprintf("Will launch directly from the image `%s`", installImage), nil
 	}
+	if len(imageOrVersion) == 0 {
+		return fmt.Sprintf("default version <https://openshift-release.svc.ci.openshift.org/releasetag/%s|%s>", installVersion, installVersion), nil
+	}
 	return fmt.Sprintf("`%s` launches version <https://openshift-release.svc.ci.openshift.org/releasetag/%s|%s>", imageOrVersion, installVersion, installVersion), nil
 }
 

--- a/pkg/prow/prow.go
+++ b/pkg/prow/prow.go
@@ -81,7 +81,7 @@ func UnstructuredToObject(in runtime.Unstructured, out runtime.Object) error {
 	return runtime.DefaultUnstructuredConverter.FromUnstructured(in.UnstructuredContent(), out)
 }
 
-func OverrideJobEnvironment(spec *prowapiv1.ProwJobSpec, image, initialImage, namespace string, variants []string) {
+func OverrideJobEnvironment(spec *prowapiv1.ProwJobSpec, image, initialImage, targetRelease, namespace string, variants []string) {
 	for i := range spec.PodSpec.Containers {
 		c := &spec.PodSpec.Containers[i]
 		for j := range c.Env {
@@ -94,6 +94,10 @@ func OverrideJobEnvironment(spec *prowapiv1.ProwJobSpec, image, initialImage, na
 				c.Env[j].Value = namespace
 			case "CLUSTER_VARIANT":
 				c.Env[j].Value = strings.Join(variants, ",")
+			case "BRANCH":
+				if len(targetRelease) > 0 {
+					c.Env[j].Value = targetRelease
+				}
 			}
 		}
 	}


### PR DESCRIPTION
`BRANCH` is used to locate images that are not part of the payload
that may be necessary for UPI installs (or other testing). Try to
detect the version from the base ref or the current payload version
(either PR or release job) in order to set it. This may have some
gaps for jobs that run custom images which will have to be fixed
later.