### PR TITLE
github: send a user-agent header for identification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /ci-chat-bot
+.idea/

--- a/manager.go
+++ b/manager.go
@@ -802,6 +802,7 @@ func (m *jobManager) resolveAsPullRequest(spec string) (*prowapiv1.Refs, error) 
 	if token := os.Getenv("GITHUB_TOKEN"); len(token) > 0 {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
+	req.Header.Add("User-Agent", "ci-chat-bot")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to lookup pull request %s: %v", spec, err)


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @smarterclayton 