### PR TITLE
Add "memo" command

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -322,6 +322,12 @@ func (b *Bot) Start(manager JobManager) error {
 		},
 	})
 
+	slack.Command("memo", &slacker.CommandDefinition{
+		Description: "No effect; use this to leave a reminder for yourself in the slack log",
+		Example: "memo trying to reproduce bz 12345",
+		Handler: func(request slacker.Request, response slacker.ResponseWriter) {},
+	})
+
 	slack.Command("version", &slacker.CommandDefinition{
 		Description: "Report the version of the bot",
 		Handler: func(request slacker.Request, response slacker.ResponseWriter) {


### PR DESCRIPTION
Sometimes I'll wonder "hey I wonder if you can do X?" and then since it's so easy to start up a cluster with cluster-bot, I'll launch a cluster. Then I go do something else for half an hour, and when cluster-bot pings me, I'm like "wait, what was thing I was going to check again?"

So I got in the habit of doing this:

> **Dan Winship**  16:23
> launch
> 
> **cluster-bot**  16:23
> a cluster is being created - I'll send you the credentials in about ~29 minutes
> 
> **Dan Winship**  16:23
> find source of ICMP redirects
> 
> **cluster-bot**  16:23
> unrecognized command, msg me `help` for a list of all commands

This adds a "memo" command so I can do that without getting an error message.

(untested since I don't know how to test it)