### PR TITLE
Ensure `build` jobs don't invoke sleep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	go build -mod vendor -o ci-chat-bot .
+	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -mod vendor -o ci-chat-bot .
 .PHONY: build
 
 update-deps:

--- a/main.go
+++ b/main.go
@@ -19,8 +19,6 @@ import (
 	projectclientset "github.com/openshift/client-go/project/clientset/versioned"
 )
 
-const Version = "0.0.1"
-
 type options struct {
 	ProwConfigPath         string
 	JobConfigPath          string

--- a/manager.go
+++ b/manager.go
@@ -561,11 +561,11 @@ func (m *jobManager) ListJobs(users ...string) string {
 			var details string
 			switch {
 			case len(job.URL) > 0 && len(job.OriginalMessage) > 0:
-				details = fmt.Sprintf("<%s|%s>", job.URL, job.OriginalMessage)
+				details = fmt.Sprintf("<%s|%s>", job.URL, stripLinks(job.OriginalMessage))
 			case len(job.URL) > 0:
 				details = fmt.Sprintf("<%s|%s>", job.URL, job.JobName)
 			case len(job.OriginalMessage) > 0:
-				details = job.OriginalMessage
+				details = stripLinks(job.OriginalMessage)
 			default:
 				details = job.JobName
 			}

--- a/slack.go
+++ b/slack.go
@@ -10,6 +10,7 @@ import (
 	prowapiv1 "github.com/openshift/ci-chat-bot/pkg/prow/apiv1"
 	"github.com/shomali11/slacker"
 	"github.com/slack-go/slack"
+	"k8s.io/client-go/pkg/version"
 	"k8s.io/klog"
 )
 
@@ -325,7 +326,7 @@ func (b *Bot) Start(manager JobManager) error {
 	slack.Command("version", &slacker.CommandDefinition{
 		Description: "Report the version of the bot",
 		Handler: func(request slacker.Request, response slacker.ResponseWriter) {
-			response.Reply(fmt.Sprintf("Thanks for asking! I'm running `%s` ( https://github.com/openshift/ci-chat-bot )", Version))
+			response.Reply(fmt.Sprintf("Running `%s` from https://github.com/openshift/ci-chat-bot", version.Get().String()))
 		},
 	})
 

--- a/slack.go
+++ b/slack.go
@@ -69,7 +69,7 @@ func (b *Bot) Start(manager JobManager) error {
 			}
 
 			msg, err := manager.LaunchJobForUser(&JobRequest{
-				OriginalMessage: request.Event().Text,
+				OriginalMessage: stripLinks(request.Event().Text),
 				User:            user,
 				Inputs:          inputs,
 				Type:            JobTypeInstall,
@@ -205,7 +205,7 @@ func (b *Bot) Start(manager JobManager) error {
 			}
 
 			msg, err := manager.LaunchJobForUser(&JobRequest{
-				OriginalMessage: request.Event().Text,
+				OriginalMessage: stripLinks(request.Event().Text),
 				User:            user,
 				Inputs:          [][]string{from, to},
 				Type:            JobTypeUpgrade,
@@ -307,7 +307,7 @@ func (b *Bot) Start(manager JobManager) error {
 			}
 
 			msg, err := manager.LaunchJobForUser(&JobRequest{
-				OriginalMessage: request.Event().Text,
+				OriginalMessage: stripLinks(request.Event().Text),
 				User:            user,
 				Inputs:          [][]string{from},
 				Type:            JobTypeBuild,
@@ -475,22 +475,41 @@ func parseImageInput(input string) ([]string, error) {
 	if len(input) == 0 {
 		return nil, nil
 	}
+	input = stripLinks(input)
 	parts := strings.Split(input, ",")
-	for i, part := range parts {
-		// strip slack formatting if applied
-		if strings.HasPrefix(part, "<") {
-			part = part[1:]
-			if index := strings.Index(part, "|"); index != -1 {
-				part = part[index+1:]
-			}
-			part = strings.TrimRight(part, ">")
-		}
+	for _, part := range parts {
 		if len(part) == 0 {
 			return nil, fmt.Errorf("image inputs must not contain empty items")
 		}
-		parts[i] = part
 	}
 	return parts, nil
+}
+
+func stripLinks(input string) string {
+	var b strings.Builder
+	for {
+		open := strings.Index(input, "<")
+		if open == -1 {
+			b.WriteString(input)
+			break
+		}
+		close := strings.Index(input[open:], ">")
+		if close == -1 {
+			b.WriteString(input)
+			break
+		}
+		pipe := strings.Index(input[open:], "|")
+		if pipe == -1 || pipe > close {
+			b.WriteString(input[0:open])
+			b.WriteString(input[open+1 : open+close])
+			input = input[open+close+1:]
+			continue
+		}
+		b.WriteString(input[0:open])
+		b.WriteString(input[open+pipe+1 : open+close])
+		input = input[open+close+1:]
+	}
+	return b.String()
 }
 
 func parseOptions(options string) (string, map[string]string, error) {


### PR DESCRIPTION
When the build jobs were refactored we started using the launch target always - this target must be replaced with `[release:latest]` when we are only building an image.

Also:

Deal with more edge cases in stripping Slack linkifying on commands

Also strip on the way out when we embed text inside of a slack response that could also be escaped (fixes a broken link on builds from PRs).

and

Output version number from build, not hardcoded

Allows us to better understand what version of code the bot is running now that it is on a different cluster.

Fixes #89