### PR TITLE
Change default cloud from aws to gcp to move balance

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -535,7 +535,7 @@ func parseOptions(options string) (string, map[string]string, error) {
 		}
 	}
 	if len(platform) == 0 {
-		platform = "aws"
+		platform = "gcp"
 	}
 	return platform, params, nil
 }


### PR DESCRIPTION
AWS tends to be saturated, use GCP by default for a while.