### PR TITLE
release: Change defaults for release branches

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -625,7 +625,7 @@ func versionForRefs(refs *prowapiv1.Refs) string {
 		return ""
 	}
 	if refs.BaseRef == "master" {
-		return "4.5.0-0.latest"
+		return "4.6.0-0.latest"
 	}
 	if m := reBranchVersion.FindStringSubmatch(refs.BaseRef); m != nil {
 		return fmt.Sprintf("%s.0-0.latest", m[2])
@@ -677,11 +677,11 @@ func (m *jobManager) resolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 			}
 			return "", "", fmt.Errorf("no stable, official prerelease, or nightly version published yet for %s", imageOrVersion)
 		} else if unresolved == "nightly" {
-			unresolved = "4.4.0-0.nightly"
+			unresolved = "4.5.0-0.nightly"
 		} else if unresolved == "ci" {
-			unresolved = "4.5.0-0.ci"
+			unresolved = "4.6.0-0.ci"
 		} else if unresolved == "prerelease" {
-			unresolved = "4.4.0-0.ci"
+			unresolved = "4.5.0-0.ci"
 		}
 
 		if tag, name := findImageStatusTag(is, unresolved); tag != nil {


### PR DESCRIPTION
Jobs based on PRs for master were selecting 4.5 as BRANCH,
resulting releases that were a mix of 4.5 and 4.6. We need
a way to associate `master` with a release without code
changes in the future.