### PR TITLE
Expose `rt` as variant

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -53,7 +53,7 @@ var supportedUpgradeTests = []string{"e2e-upgrade", "e2e-upgrade-all", "e2e-upgr
 var supportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal"}
 
 // supportedParameters are the allowed parameter keys that can be passed to jobs
-var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test"}
+var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt"}
 
 var (
 	// reReleaseVersion detects whether a branch appears to correlate to a release branch


### PR DESCRIPTION
This should already be supported, see
https://github.com/openshift/release/blob/e5e6d1cfb1a5a11c8ebb8c1f8974712e02af7aef/ci-operator/templates/openshift/installer/cluster-launch-installer-e2e.yaml#L842