### PR TITLE
enable applying RT kernel type on master nodes

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -53,7 +53,7 @@ var supportedUpgradeTests = []string{"e2e-upgrade", "e2e-upgrade-all", "e2e-upgr
 var supportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal"}
 
 // supportedParameters are the allowed parameter keys that can be passed to jobs
-var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt"}
+var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt", "rt-master"}
 
 var (
 	// reReleaseVersion detects whether a branch appears to correlate to a release branch


### PR DESCRIPTION
We want to apply RT kernel type on master nodes as well.
Previous "rt" variant is kept for preserving compatibility.

/hold dependent on openshift/release#14020