### PR TITLE
add single-node variant for applying cluster profile of single node

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -53,7 +53,7 @@ var supportedUpgradeTests = []string{"e2e-upgrade", "e2e-upgrade-all", "e2e-upgr
 var supportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal"}
 
 // supportedParameters are the allowed parameter keys that can be passed to jobs
-var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt"}
+var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt", "single-node"}
 
 var (
 	// reReleaseVersion detects whether a branch appears to correlate to a release branch


### PR DESCRIPTION
Compliments openshift/release#14556
We want to apply cluster profile of single-node, which enables 1 node that acts as control plane and compute resource