### PR TITLE
Adjustments to cluster-bot to support step based periodics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ build:
 	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -mod vendor -o ci-chat-bot .
 .PHONY: build
 
+debug:
+	go build -gcflags="all=-N -l" -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -mod vendor -o ci-chat-bot .
+.PHONY: build
+
 update-deps:
 	GO111MODULE=on go mod vendor
 .PHONY: update-deps

--- a/manager.go
+++ b/manager.go
@@ -363,7 +363,7 @@ func (m *jobManager) sync() error {
 			j.State = prowapiv1.PendingState
 			j.Failure = ""
 
-			if j.Mode == "launch" {
+			if j.Mode == "launch" && (previous != nil && !previous.Complete) {
 				if user := j.RequestedBy; len(user) > 0 {
 					if _, ok := m.requests[user]; !ok {
 						var inputStrings [][]string

--- a/manager.go
+++ b/manager.go
@@ -1198,14 +1198,15 @@ func (m *jobManager) TerminateJobForUser(user string) (string, error) {
 		return "", err
 	}
 
+	if err := m.stopJob(name); err != nil {
+		return "", fmt.Errorf("unable to terminate: %v", err)
+	}
+
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
 	klog.Infof("user %q requests job %q to be terminated", user, name)
 	if job, ok := m.jobs[name]; ok {
-		if err := m.stopJob(job); err != nil {
-			klog.Errorf("unable to terminate running cluster %s: %v", name, err)
-		}
 		job.Failure = "deletion requested"
 		job.ExpiresAt = time.Now().Add(15 * time.Minute)
 		job.Complete = true


### PR DESCRIPTION
1. Post-steps do not run if `stopJob` deletes the entire project.
Changed to terminate ci-operator pod, which triggers post-steps to
run and for templates to gracefully teardown.
2. Step based jobs follow a pod/container naming convention different than
the traditional template jobs. Instead trying to reflect this, step based
jobs will monitor a secret in the test namespace to extract
cluster information. Access to this secret must be granted by the
openshift-cluster-bot-rbac registry step.