### PR TITLE
Check /tmp/shared for kubeadmin-password

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -651,6 +651,9 @@ func (m *jobManager) waitForJob(job *Job) error {
 
 	password, err := commandContents(m.coreClient.CoreV1(), m.coreConfig, namespace, targetPodName, "test", []string{"cat", "/tmp/artifacts/installer/auth/kubeadmin-password"})
 	if err != nil {
+		password, err = commandContents(m.coreClient.CoreV1(), m.coreConfig, namespace, targetPodName, "test", []string{"cat", "/tmp/shared/installer/auth/kubeadmin-password"})
+	}
+	if err != nil {
 		klog.Infof("error: Job %q unable to get kubeadmin password: %v", job.Name, err)
 		job.PasswordSnippet = fmt.Sprintf("\nError: Unable to retrieve kubeadmin password, you must use the kubeconfig file to access the cluster: %v", err)
 	} else {


### PR DESCRIPTION
Some templates (metal so far) have been updated to not use
/tmp/artifacts/installer for running the installer.  For security, the
installer assest are in /tmp/shared.

See https://bugzilla.redhat.com/show_bug.cgi?id=1920629