### PR TITLE
Passing ARTIFACTS as an environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func run() error {
 	klog.InitFlags(emptyFlags)
 	opt := &options{
 		GithubEndpoint: "https://api.github.com",
-		ConfigResolver: "http://ci-operator-configresolver.ci.svc/config",
+		ConfigResolver: "http://config.ci.openshift.org/config",
 	}
 	pflag.StringVar(&opt.ConfigResolver, "config-resolver", opt.ConfigResolver, "A URL pointing to a config resolver for retrieving ci-operator config. You may pass a location on disk with file://<abs_path_to_ci_operator_config>")
 	pflag.StringVar(&opt.ProwConfigPath, "prow-config", opt.ProwConfigPath, "A config file containing the prow configuration.")

--- a/prow.go
+++ b/prow.go
@@ -856,8 +856,7 @@ if [[ -z "${RELEASE_IMAGE_LATEST-}" ]]; then
 fi
 
 # import the initial release, if any
-UNRESOLVED_CONFIG=$INITIAL ci-operator \
-  --artifact-dir=$(ARTIFACTS)/initial \
+UNRESOLVED_CONFIG=$INITIAL ARTIFACTS=$(ARTIFACTS)/initial ci-operator \
   --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson \
   --namespace=$(NAMESPACE) \
   --delete-when-idle=$(PRESERVE_DURATION) \
@@ -875,8 +874,7 @@ for var in "${!CONFIG_SPEC_@}"; do
   (
     set +e
     echo "Starting $suffix ..."
-    JOB_SPEC="${!jobvar}" UNRESOLVED_CONFIG="${!var}" ci-operator \
-      --artifact-dir=$(ARTIFACTS)/$suffix \
+    JOB_SPEC="${!jobvar}" ARTIFACTS=$(ARTIFACTS)/$suffix UNRESOLVED_CONFIG="${!var}" ci-operator \
       --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson \
       --namespace=$(NAMESPACE)-${suffix} \
       --target=[images] -promote >"$(ARTIFACTS)/$suffix/build.log" 2>&1


### PR DESCRIPTION
DPTP merged a change that removed support for the `--artifact-dir` paramenter to the `ci-operator`:
https://github.com/openshift/ci-tools/pull/1731
This PR converts the logic over to pass the value as an environment variable into the call to the ci-operator.