### PR TITLE
Use new registry_override field when promoting build jobs

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"gopkg.in/fsnotify.v1"
 	"log"
 	"net/url"
 	"os"
 	"time"
+
+	"gopkg.in/fsnotify.v1"
 
 	"github.com/spf13/pflag"
 
@@ -87,6 +88,11 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("unable to create client: %v", err)
 	}
+	targetImageClient, err := imageclientset.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("unable to create image client: %v", err)
+	}
+
 	// Config and Client to access release images
 	releaseConfig, err := loadKubeconfigFromFlagOrDefault(opt.ReleaseClusterKubeconfig, prowJobKubeconfig)
 	imageClient, err := imageclientset.NewForConfig(releaseConfig)
@@ -103,7 +109,7 @@ func run() error {
 		return err
 	}
 
-	manager := NewJobManager(configAgent, resolver, prowClient, client, imageClient, projectClient, config, opt.GithubEndpoint, opt.ForcePROwner)
+	manager := NewJobManager(configAgent, resolver, prowClient, client, imageClient, targetImageClient, projectClient, config, opt.GithubEndpoint, opt.ForcePROwner)
 	if err := manager.Start(); err != nil {
 		return fmt.Errorf("unable to load initial configuration: %v", err)
 	}

--- a/manager.go
+++ b/manager.go
@@ -155,15 +155,16 @@ type jobManager struct {
 	maxClusters   int
 	maxAge        time.Duration
 
-	prowConfigLoader prow.ProwConfigLoader
-	prowClient       dynamic.NamespaceableResourceInterface
-	coreClient       clientset.Interface
-	imageClient      imageclientset.Interface
-	projectClient    projectclientset.Interface
-	coreConfig       *rest.Config
-	prowNamespace    string
-	githubURL        string
-	forcePROwner     string
+	prowConfigLoader  prow.ProwConfigLoader
+	prowClient        dynamic.NamespaceableResourceInterface
+	coreClient        clientset.Interface
+	imageClient       imageclientset.Interface
+	targetImageClient imageclientset.Interface
+	projectClient     projectclientset.Interface
+	coreConfig        *rest.Config
+	prowNamespace     string
+	githubURL         string
+	forcePROwner      string
 
 	configResolver ConfigResolver
 
@@ -185,6 +186,7 @@ func NewJobManager(
 	prowClient dynamic.NamespaceableResourceInterface,
 	coreClient clientset.Interface,
 	imageClient imageclientset.Interface,
+	targetImageClient imageclientset.Interface,
 	projectClient projectclientset.Interface,
 	config *rest.Config,
 	githubURL, forcePROwner string,
@@ -197,14 +199,15 @@ func NewJobManager(
 		maxAge:        3 * time.Hour,
 		githubURL:     githubURL,
 
-		prowConfigLoader: prowConfigLoader,
-		prowClient:       prowClient,
-		coreClient:       coreClient,
-		coreConfig:       config,
-		imageClient:      imageClient,
-		projectClient:    projectClient,
-		prowNamespace:    "ci",
-		forcePROwner:     forcePROwner,
+		prowConfigLoader:  prowConfigLoader,
+		prowClient:        prowClient,
+		coreClient:        coreClient,
+		coreConfig:        config,
+		imageClient:       imageClient,
+		targetImageClient: targetImageClient,
+		projectClient:     projectClient,
+		prowNamespace:     "ci",
+		forcePROwner:      forcePROwner,
 
 		configResolver: configResolver,
 	}


### PR DESCRIPTION
Now that promotion uses mirroring exclusively, we need to prepare
a pull secret using the pod's service account for use when promoting
from the build namespace (<ns>-N) to the main namespace (<ns>). We
need to know the public URL because the promotion step uses the public
facing URL of the cluster for the input image.

Long term chat bot also needs to change to load the appropriate cluster
config from the build-kubeconfig based on the job, then spawn clients
(the current behavior only accidentally works as long as the job and
chat bot config points to the same dir).