### PR TITLE
Updating release-controller URLs

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -527,7 +527,7 @@ func (m *jobManager) ListJobs(users ...string) string {
 			}
 			switch {
 			case len(jobInput.Version) > 0:
-				inputParts = append(inputParts, fmt.Sprintf("<https://openshift-release.svc.ci.openshift.org/releasetag/%s|%s>", url.PathEscape(jobInput.Version), jobInput.Version))
+				inputParts = append(inputParts, fmt.Sprintf("<https://amd64.ocp.releases.ci.openshift.org/releasetag/%s|%s>", url.PathEscape(jobInput.Version), jobInput.Version))
 			case len(jobInput.Image) > 0:
 				inputParts = append(inputParts, "(image)")
 			}
@@ -707,7 +707,7 @@ func (m *jobManager) resolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 		}
 	}
 
-	return "", "", fmt.Errorf("unable to find a release matching %q on https://openshift-release.svc.ci.openshift.org or https://origin-release.svc.ci.openshift.org", imageOrVersion)
+	return "", "", fmt.Errorf("unable to find a release matching %q on https://amd64.ocp.releases.ci.openshift.org or https://origin-release.svc.ci.openshift.org", imageOrVersion)
 }
 
 func findNewestStableImageSpecTagBySemanticMajor(is *imagev1.ImageStream, majorMinor string) *imagev1.TagReference {
@@ -798,7 +798,7 @@ func (m *jobManager) LookupInputs(inputs []string) (string, error) {
 			out = append(out, fmt.Sprintf("`%s` uses version `%s`", inputs[i], job.Version))
 			continue
 		}
-		out = append(out, fmt.Sprintf("`%s` launches version <https://openshift-release.svc.ci.openshift.org/releasetag/%s|%s>", inputs[i], job.Version, job.Version))
+		out = append(out, fmt.Sprintf("`%s` launches version <https://amd64.ocp.releases.ci.openshift.org/releasetag/%s|%s>", inputs[i], job.Version, job.Version))
 	}
 	return strings.Join(out, "\n"), nil
 }

--- a/slack.go
+++ b/slack.go
@@ -35,7 +35,7 @@ func (b *Bot) Start(manager JobManager) error {
 
 	slack.Command("launch <image_or_version_or_pr> <options>", &slacker.CommandDefinition{
 		Description: fmt.Sprintf(
-			"Launch an OpenShift cluster using a known image, version, or PR. You may omit both arguments. Use `nightly` for the latest OCP build, `ci` for the the latest CI build, provide a version directly from any listed on https://openshift-release.svc.ci.openshift.org, a stream name (4.1.0-0.ci, 4.1.0-0.nightly, etc), a major/minor `X.Y` to load the latest stable version for that version (`4.1`), `<org>/<repo>#<pr>` to launch from a PR, or an image for the first argument. Options is a comma-delimited list of variations including platform (%s) and variant (%s).",
+			"Launch an OpenShift cluster using a known image, version, or PR. You may omit both arguments. Use `nightly` for the latest OCP build, `ci` for the the latest CI build, provide a version directly from any listed on https://amd64.ocp.releases.ci.openshift.org, a stream name (4.1.0-0.ci, 4.1.0-0.nightly, etc), a major/minor `X.Y` to load the latest stable version for that version (`4.1`), `<org>/<repo>#<pr>` to launch from a PR, or an image for the first argument. Options is a comma-delimited list of variations including platform (%s) and variant (%s).",
 			strings.Join(codeSlice(supportedPlatforms), ", "),
 			strings.Join(codeSlice(supportedParameters), ", "),
 		),
@@ -163,7 +163,7 @@ func (b *Bot) Start(manager JobManager) error {
 	})
 
 	slack.Command("test upgrade <from> <to> <options>", &slacker.CommandDefinition{
-		Description: fmt.Sprintf("Run the upgrade tests between two release images. The arguments may be a pull spec of a release image or tags from https://openshift-release.svc.ci.openshift.org. You may change the upgrade test by passing `test=NAME` in options with one of %s", strings.Join(codeSlice(supportedUpgradeTests), ", ")),
+		Description: fmt.Sprintf("Run the upgrade tests between two release images. The arguments may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org. You may change the upgrade test by passing `test=NAME` in options with one of %s", strings.Join(codeSlice(supportedUpgradeTests), ", ")),
 		Handler: func(request slacker.Request, response slacker.ResponseWriter) {
 			user := request.Event().User
 			channel := request.Event().Channel
@@ -224,7 +224,7 @@ func (b *Bot) Start(manager JobManager) error {
 	})
 
 	slack.Command("test <name> <image_or_version_or_pr> <options>", &slacker.CommandDefinition{
-		Description: fmt.Sprintf("Run the requested test suite from an image or release or built PRs. Supported test suites are %s. The from argument may be a pull spec of a release image or tags from https://openshift-release.svc.ci.openshift.org.", strings.Join(codeSlice(supportedTests), ", ")),
+		Description: fmt.Sprintf("Run the requested test suite from an image or release or built PRs. Supported test suites are %s. The from argument may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org. ", strings.Join(codeSlice(supportedTests), ", ")),
 		Handler: func(request slacker.Request, response slacker.ResponseWriter) {
 			user := request.Event().User
 			channel := request.Event().Channel


### PR DESCRIPTION
Switching the release-controller URLs over to their new location, on the `app.ci` cluster.