### PR TITLE
Provide user with kubeconfig in any case

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -381,7 +381,9 @@ func (b *Bot) notifyJob(response slacker.ResponseWriter, job *Job) {
 				comment += "\n" + job.PasswordSnippet
 			}
 			b.sendKubeconfig(response, job.RequestedChannel, job.Credentials, comment, job.RequestedAt.Format("2006-01-02-150405"))
+			return
 		}
+		b.sendKubeconfig(response, job.RequestedChannel, job.Credentials, "kubeconfig:", job.RequestedAt.Format("2006-01-02-150405"))
 		return
 	}
 


### PR DESCRIPTION
The bot currently doesn't provide the user with a kubeconfig in case
the cluster failed to launch. I however, sometimes, don't need a fully
working cluster deployment to test/check what I need. Moreover: I
might sometimes care to look at what didn't work and try to fix it.
Hence: provide the user the kubeconfig, no matter what.

/assign @smarterclayton 