### PR TITLE
Importing a release stream for a PR build was broken

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -675,16 +675,16 @@ func (m *jobManager) resolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 		}
 
 		if m := reMajorMinorVersion.FindStringSubmatch(unresolved); m != nil {
-			if tag := findNewestStableImageSpecTagBySemanticMajor(is, unresolved); tag != nil {
-				klog.Infof("Resolved major.minor %s to semver tag %s", imageOrVersion, tag.Name)
-				return buildPullSpec(ns, tag.Name), tag.Name, nil
-			}
 			if tag := findNewestImageSpecTagWithStream(is, fmt.Sprintf("%s.0-0.nightly", unresolved)); tag != nil {
 				klog.Infof("Resolved major.minor %s to nightly tag %s", imageOrVersion, tag.Name)
 				return buildPullSpec(ns, tag.Name), tag.Name, nil
 			}
 			if tag := findNewestImageSpecTagWithStream(is, fmt.Sprintf("%s.0-0.ci", unresolved)); tag != nil {
 				klog.Infof("Resolved major.minor %s to ci tag %s", imageOrVersion, tag.Name)
+				return buildPullSpec(ns, tag.Name), tag.Name, nil
+			}
+			if tag := findNewestStableImageSpecTagBySemanticMajor(is, unresolved); tag != nil {
+				klog.Infof("Resolved major.minor %s to semver tag %s", imageOrVersion, tag.Name)
 				return buildPullSpec(ns, tag.Name), tag.Name, nil
 			}
 			return "", "", fmt.Errorf("no stable, official prerelease, or nightly version published yet for %s", imageOrVersion)

--- a/prow.go
+++ b/prow.go
@@ -873,11 +873,19 @@ echo "{\"auths\":{\"${registry_host}\":{\"auth\":\"${encoded_token}\"}}}" > /tmp
 
 mkdir -p "$(ARTIFACTS)/initial" "$(ARTIFACTS)/final"
 
+targets=()
 if [[ -z "${RELEASE_IMAGE_INITIAL-}" ]]; then
   unset RELEASE_IMAGE_INITIAL
+else
+  targets+=("--target=[release:initial]")
 fi
 if [[ -z "${RELEASE_IMAGE_LATEST-}" ]]; then
   unset RELEASE_IMAGE_LATEST
+else
+  targets+=("--target=[release:latest]")
+fi
+if [[ -z "${targets}" ]]; then
+	targets+=("--target=[images]")
 fi
 
 # import the initial release, if any
@@ -886,7 +894,7 @@ UNRESOLVED_CONFIG=$INITIAL ARTIFACTS=$(ARTIFACTS)/initial ci-operator \
   --image-mirror-push-secret=/tmp/push-auth \
   --namespace=$(NAMESPACE) \
   --delete-when-idle=$(PRESERVE_DURATION) \
-  --target=[release-inputs]
+  "${targets[@]}"
 
 unset RELEASE_IMAGE_INITIAL
 unset RELEASE_IMAGE_LATEST


### PR DESCRIPTION
ci-operator --target=[release-inputs] changed behavior a while back
and we didn't notice. The effective replacement (populate stable
with tag_spec and then layer on release image) is --target=[release:latest]

/hold

Still need to test with `test upgrade PR release`