### PR TITLE
Importing a release stream for a PR build was broken

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -892,6 +892,7 @@ fi
 UNRESOLVED_CONFIG=$INITIAL ARTIFACTS=$(ARTIFACTS)/initial ci-operator \
   --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson \
   --image-mirror-push-secret=/tmp/push-auth \
+  --gcs-upload-secret=/secrets/gcs/service-account.json \
   --namespace=$(NAMESPACE) \
   --delete-when-idle=$(PRESERVE_DURATION) \
   "${targets[@]}"
@@ -911,6 +912,7 @@ for var in "${!CONFIG_SPEC_@}"; do
     JOB_SPEC="${!jobvar}" ARTIFACTS=$(ARTIFACTS)/$suffix UNRESOLVED_CONFIG="${!var}" ci-operator \
       --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson \
       --image-mirror-push-secret=/tmp/push-auth \
+      --gcs-upload-secret=/secrets/gcs/service-account.json \
       --namespace=$(NAMESPACE)-${suffix} \
       --target=[images] -promote >"$(ARTIFACTS)/$suffix/build.log" 2>&1
     code=$?


### PR DESCRIPTION
ci-operator --target=[release-inputs] changed behavior a while back
and we didn't notice. The effective replacement (populate stable
with tag_spec and then layer on release image) is --target=[release:latest]