### PR TITLE
Improve the help text for building release images from PRs

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -283,8 +283,8 @@ func (b *Bot) Start(manager JobManager) error {
 		},
 	})
 
-	slack.Command("build <from>", &slacker.CommandDefinition{
-		Description: "Create a new release image from one or more pull requests. The successful build location will be sent to you when it completes and then preserved for 12 hours.",
+	slack.Command("build <pullrequest>", &slacker.CommandDefinition{
+		Description: "Create a new release image from one or more pull requests. The successful build location will be sent to you when it completes and then preserved for 12 hours.  Example: `build openshift/operator-framework-olm#68,operator-framework/operator-marketplace#396`",
 		Handler: func(request slacker.Request, response slacker.ResponseWriter) {
 			user := request.Event().User
 			channel := request.Event().Channel
@@ -293,7 +293,7 @@ func (b *Bot) Start(manager JobManager) error {
 				return
 			}
 
-			from, err := parseImageInput(request.StringParam("from", ""))
+			from, err := parseImageInput(request.StringParam("pullrequest", ""))
 			if err != nil {
 				response.Reply(err.Error())
 				return


### PR DESCRIPTION
It's not clear from my quick survey of the code if this command can support other "from" sources besides PRs...   if it can, this PR is incorrect since it modifies the help text to be specifically targeted at how to build a release image based on PRs.
