### PR TITLE
Checking /tmp/shared for the installer kubeadmin-password

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -801,10 +801,11 @@ func (m *jobManager) waitForJob(job *Job) error {
 		job.PasswordSnippet = strings.TrimSpace(reFixLines.ReplaceAllString(string(logs), "$1"))
 		password, err := commandContents(clusterClient.CoreClient.CoreV1(), clusterClient.CoreConfig, namespace, targetName, "test", []string{"cat", "/tmp/artifacts/installer/auth/kubeadmin-password"})
 		if err != nil {
+			klog.Infof("error: Job %q unable to get kubeadmin password: %v", job.Name, err)
 			password, err = commandContents(clusterClient.CoreClient.CoreV1(), clusterClient.CoreConfig, namespace, targetName, "test", []string{"cat", "/tmp/shared/installer/auth/kubeadmin-password"})
 		}
 		if err != nil {
-			klog.Infof("error: Job %q unable to get kubeadmin password: %v", job.Name, err)
+			klog.Infof("error: Job %q unable to locate kubeadmin password: %v", job.Name, err)
 		} else {
 			kubeadminPassword = password
 		}

--- a/prow.go
+++ b/prow.go
@@ -801,6 +801,9 @@ func (m *jobManager) waitForJob(job *Job) error {
 		job.PasswordSnippet = strings.TrimSpace(reFixLines.ReplaceAllString(string(logs), "$1"))
 		password, err := commandContents(clusterClient.CoreClient.CoreV1(), clusterClient.CoreConfig, namespace, targetName, "test", []string{"cat", "/tmp/artifacts/installer/auth/kubeadmin-password"})
 		if err != nil {
+			password, err = commandContents(clusterClient.CoreClient.CoreV1(), clusterClient.CoreConfig, namespace, targetName, "test", []string{"cat", "/tmp/shared/installer/auth/kubeadmin-password"})
+		}
+		if err != nil {
 			klog.Infof("error: Job %q unable to get kubeadmin password: %v", job.Name, err)
 		} else {
 			kubeadminPassword = password


### PR DESCRIPTION
The `metal` team updated their installer job to utilize the
/tmp/shared location for the installer's artifacts (because they
were leaking secrets when everything was placed under the
/tmp/artifacts location). This PR adds a secondary check to
look for the file, in /tmp/shared, if the first check, in
/tmp/artifacts, fails for any reason.