### PR TITLE
Make hack/linter.sh output on failure

### DIFF
--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -30,12 +30,12 @@ INFO:      # go mod tidy
 EOF
 
 echo "Checking go formatting..."
-(cd ${base_dir}; gofmt -w $(find . -type f -a -name '*.go' | grep -v /vendor/) && git add --intent-to-add . && git diff --quiet --exit-code .)
+(cd ${base_dir}; gofmt -w $(find . -type f -a -name '*.go' | grep -v /vendor/) && git add --intent-to-add . && git diff --exit-code .)
 
 echo "Checking go vendoring..."
-(cd ${base_dir}; go mod vendor && git add --intent-to-add . && git diff --quiet --exit-code .)
+(cd ${base_dir}; go mod vendor && git add --intent-to-add . && git diff --exit-code .)
 
 echo "Checking go mod tidy..."
-(cd ${base_dir}; go mod tidy && git add --intent-to-add . && git diff --quiet --exit-code .)
+(cd ${base_dir}; go mod tidy && git add --intent-to-add . && git diff --exit-code .)
 
 exit 0


### PR DESCRIPTION
The `--quiet` option to `git diff` meant that the logs of a [failure](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-chat-bot/175/pull-ci-openshift-ci-chat-bot-master-linter/1405192837577838592), looked just the same as those of a [success](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-chat-bot/175/pull-ci-openshift-ci-chat-bot-master-linter/1405194515370741760). Remove that option so the output contains the delta we think you need to
commit to satisfy the test.