### PR TITLE
add 4.9 to cluster-bot

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -639,7 +639,7 @@ func versionForRefs(refs *prowapiv1.Refs) string {
 		return ""
 	}
 	if refs.BaseRef == "master" {
-		return "4.8.0-0.latest"
+		return "4.9.0-0.latest"
 	}
 	if m := reBranchVersion.FindStringSubmatch(refs.BaseRef); m != nil {
 		return fmt.Sprintf("%s.0-0.latest", m[2])
@@ -691,11 +691,11 @@ func (m *jobManager) resolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 			}
 			return "", "", fmt.Errorf("no stable, official prerelease, or nightly version published yet for %s", imageOrVersion)
 		} else if unresolved == "nightly" {
-			unresolved = "4.8.0-0.nightly"
+			unresolved = "4.9.0-0.nightly"
 		} else if unresolved == "ci" {
-			unresolved = "4.8.0-0.ci"
+			unresolved = "4.9.0-0.ci"
 		} else if unresolved == "prerelease" {
-			unresolved = "4.8.0-0.ci"
+			unresolved = "4.9.0-0.ci"
 		}
 
 		if tag, name := findImageStatusTag(is, unresolved); tag != nil {


### PR DESCRIPTION
Now that the 4.9 release branch is cut, cluster-bot should default to 4.9 for "prerelease", "nightly", and "ci".