### PR TITLE
Add support for cgroupsv2 varient

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -53,7 +53,7 @@ var supportedUpgradeTests = []string{"e2e-upgrade", "e2e-upgrade-all", "e2e-upgr
 var supportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal", "hypershift"}
 
 // supportedParameters are the allowed parameter keys that can be passed to jobs
-var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt", "single-node"}
+var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt", "single-node", "cgroupsv2"}
 
 // supportedArchitectures are the allowed architectures that can be passed to jobs
 var supportedArchitectures = []string{"amd64"}


### PR DESCRIPTION
This PR adds support for cgroupsv2 varient in cluster-bot. The [PR](https://github.com/openshift/release/pull/19956/files#diff-a73b08887ec6ccd5778c1915a196dea5a79038c959f87b4fd1bb886ced4911c3R847) to add cgroupsv2 variant is already under review, marking this PR WIP till then. 

Signed-off-by: Harshal Patil <harpatil@redhat.com>