### PR TITLE
Bump quota to 48 clusters from 36 clusters

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -38,7 +38,7 @@ const (
 
 	// maxTotalClusters limits the number of simultaneous clusters across all users to
 	// prevent saturating the infrastructure account.
-	maxTotalClusters = 36
+	maxTotalClusters = 48
 )
 
 // JobRequest keeps information about the request a user made to create


### PR DESCRIPTION
We are now sitting at the limit, and we do have slack capacity in
a number of environments.