### PR TITLE
Abort ProwJob instead of removing it

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -159,10 +159,10 @@ func (m *jobManager) stopJob(name, cluster string) error {
 		return err
 	}
 
-	// Deleting the prowjob pod will gracefully terminate template or step based jobs. In the case of
-	// steps, this includes running post steps.
-	klog.Infof("ProwJob pod for job %q will be deleted", name)
-	return m.clusterClients[cluster].CoreClient.CoreV1().Pods(m.prowNamespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	klog.Infof("ProwJob pod for job %q will be aborted", name)
+	pj.Status.State = prowapiv1.AbortedState
+	_, err = m.prowClient.Namespace(m.prowNamespace).Update(context.Background(), prow.ObjectToUnstructured(&pj), metav1.UpdateOptions{})
+	return err
 }
 
 // newJob creates a ProwJob for running the provided job and exits.


### PR DESCRIPTION
Set AbortedState and update pj instead of deleting the object. This would ensure template/workflow objects are being correctly terminated.
Verified that it properly stops workflow-based tests, but I don't have permissions to ensure template-based clusters are stopped as expected.