### PR TITLE
Use correct kconfig flag in run script

### DIFF
--- a/hack/run.sh
+++ b/hack/run.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 
 if [[ -z $BOT_TOKEN ]]; then echo "BOT_TOKEN var must be set"; exit 1; fi
 
-tmp_kk=$(mktemp)
-trap 'rm -rf $tmp_kk' EXIT
+tmp_dir=$(mktemp -d)
+tmp_kk=$tmp_dir/build.kubeconfig
+trap 'rm -rf $tmp_dir' EXIT
 
 kubectl config view >$tmp_kk
 kubectl --kubeconfig=$tmp_kk config use-context app.ci
@@ -18,5 +19,5 @@ make
   --force-pr-owner=system:serviceaccount:ci:ci-chat-bot \
   --job-config ../release/ci-operator/jobs/openshift/release/ \
   --prow-config ../release/core-services/prow/02_config/_config.yaml \
-  --build-cluster-kubeconfig=$tmp_kk \
+  --build-cluster-kubeconfigs-location=$tmp_dir \
   --v=2


### PR DESCRIPTION
The flag `--build-cluster-kubeconfigs` has been deprecated and has no effect.
The correct flag to use in the run script is `--build-cluster-kubeconfigs-location`.

Prior to this change you would get the following error on running cluster-bot locally since the `--build-cluster-kubeconfigs-location` flag was unset and would default to `/var/build-cluster-kubeconfigs`:
```console
$ BOT_TOKEN=... ./hack/run.sh
2021/07/28 15:56:31 unable to load build cluster configurations: unable to access location "/var/build-cluster-kubeconfigs": open /var/build-cluster-kubeconfigs: no such file or directory
```