### PR TITLE
Local execution enhancements

### DIFF
--- a/hack/run.sh
+++ b/hack/run.sh
@@ -6,16 +6,21 @@ if [[ -z $BOT_TOKEN ]]; then echo "BOT_TOKEN var must be set"; exit 1; fi
 if [[ -z $BOT_APP_TOKEN ]]; then echo "BOT_APP_TOKEN var must be set"; exit 1; fi
 
 tmp_dir=$(mktemp -d)
-tmp_kk=$tmp_dir/build.kubeconfig
+tmp_kk=$tmp_dir/app.ci.kubeconfig
 trap 'rm -rf $tmp_dir' EXIT
 
 kubectl config view >$tmp_kk
 kubectl --kubeconfig=$tmp_kk config use-context app.ci
 
+# Entries for the BuildClusterClientConfigMap...
+cp $tmp_kk $tmp_dir/build01.kubeconfig
+cp $tmp_kk $tmp_dir/build02.kubeconfig
+cp $tmp_kk $tmp_dir/vsphere.kubeconfig
 
 kubectl config use-context app.ci
 cd $(dirname $0)/..
 make
+
 ./ci-chat-bot \
   --force-pr-owner=system:serviceaccount:ci:ci-chat-bot \
   --job-config ../release/ci-operator/jobs/openshift/release/ \

--- a/slack.go
+++ b/slack.go
@@ -48,7 +48,7 @@ func getUserProfile(client slacker.BotContext) *slack.User {
 	return userProfile
 }
 
-func (b *Bot) Start(manager JobManager) error {
+func (b *Bot) Start(context context.Context, manager JobManager) error {
 	client := slacker.NewClient(b.botToken, b.botAppToken)
 	// client := slacker.NewClient(b.botToken, b.botAppToken, slacker.WithBotInteractionMode(slacker.BotInteractionModeIgnoreApp))
 
@@ -513,7 +513,7 @@ func (b *Bot) Start(manager JobManager) error {
 	})
 
 	klog.Infof("ci-chat-bot up and listening to slack")
-	return client.Listen(context.Background())
+	return client.Listen(context)
 }
 
 func getPlatformArchFromWorkflowConfig(workflowConfig *WorkflowConfig, name string) (string, string, error) {


### PR DESCRIPTION
A few more folks have inquired about making changes to the cluster-bot and how to test it.  I started looking into the current `hack/run.sh` and found a few things that needed to be addressed:

1. Proper interrupt handling
The script would launch the cluster-bot properly, but ^C wouldn't actually break out of the running program.  I added signal handling to the initialization of the cluster-bot.
2. The `BuildClusterClientConfigMap` is not being populated with the necessary values for the various build clusters
I added logic to copy the users kubeconfig over to cluster specific (`build01.kubeconfig`, `build02.kubeconfig`, `vsphere.kubeconfig`) kubeconfigs.  Although this doesn't necessarily give users the ability to interrogate the environment on these clusters (they will see `Unauthorizied` messages in the log), it does setup the configuration for when we get the appropriate RBAC necessary on these clusters to do so.