### PR TITLE
Change the current reference master version to 4.9

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -639,7 +639,7 @@ func versionForRefs(refs *prowapiv1.Refs) string {
 		return ""
 	}
 	if refs.BaseRef == "master" {
-		return "4.8.0-0.latest"
+		return "4.9.0-0.latest"
 	}
 	if m := reBranchVersion.FindStringSubmatch(refs.BaseRef); m != nil {
 		return fmt.Sprintf("%s.0-0.latest", m[2])


### PR DESCRIPTION
@bradmwilliams @smarterclayton The reference of master version are still 4.8 in the ci-chat-bot, this will result in us not getting the correct master version for launching cluster-bot with 4.9 PRs. Please help review.