### PR TITLE
Add ovirt supported platform

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -50,7 +50,7 @@ var supportedUpgradeTests = []string{"e2e-upgrade", "e2e-upgrade-all", "e2e-upgr
 
 // supportedPlatforms requires a job within the release periodics that can launch a
 // cluster that has the label job-env: platform-name.
-var supportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal", "hypershift"}
+var supportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal", "hypershift", "ovirt"}
 
 // supportedParameters are the allowed parameter keys that can be passed to jobs
 var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt", "single-node"}


### PR DESCRIPTION
Launch task was added in https://github.com/openshift/release/pull/21784.

Tested locally and its coming up correctly, must-gather and deprovision steps are executed as expected on shutdown