### PR TITLE
Rename metal to metal-ipi to avoid confusion

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -50,7 +50,7 @@ var supportedUpgradeTests = []string{"e2e-upgrade", "e2e-upgrade-all", "e2e-upgr
 
 // supportedPlatforms requires a job within the release periodics that can launch a
 // cluster that has the label job-env: platform-name.
-var supportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal", "hypershift", "ovirt"}
+var supportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal-ipi", "hypershift", "ovirt"}
 
 // supportedParameters are the allowed parameter keys that can be passed to jobs
 var supportedParameters = []string{"ovn", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt", "single-node"}


### PR DESCRIPTION
Although metal is in supported platform list, it can not be used.
This PR renames metal platform type to metal-ipi to avoid possible
confusions.

This PR is dependent to https://github.com/openshift/release/pull/21150 to run `metal-ipi` clusters via cluster-bot.