### PR TITLE
Don't declare tag_specification

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -379,11 +379,6 @@ func (m *jobManager) newJob(job *Job) error {
 		default:
 			return fmt.Errorf("the prow job %s does not have a recognizable command/args setup and cannot be used with pull request builds", job.JobName)
 		}
-
-		sourceConfig.Object["tag_specification"] = map[string]interface{}{
-			"name":      "pipeline",
-			"namespace": "$(NAMESPACE)",
-		}
 		if tests, ok := sourceConfig.Object["tests"].([]interface{}); !ok || len(tests) == 0 {
 			sourceConfig.Object["tests"] = []interface{}{
 				map[string]interface{}{
@@ -427,20 +422,12 @@ func (m *jobManager) newJob(job *Job) error {
 						"registry_override":   registryHost,
 						"disable_build_cache": true,
 					}
-					targetConfig.Object["tag_specification"] = map[string]interface{}{
-						"name":      "stable-initial",
-						"namespace": "$(NAMESPACE)",
-					}
 				} else {
 					targetConfig.Object["promotion"] = map[string]interface{}{
 						"name":                "stable",
 						"namespace":           "$(NAMESPACE)",
 						"registry_override":   registryHost,
 						"disable_build_cache": true,
-					}
-					targetConfig.Object["tag_specification"] = map[string]interface{}{
-						"name":      "stable",
-						"namespace": "$(NAMESPACE)",
 					}
 				}
 
@@ -992,9 +979,6 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-tag_specification:
-  name: "$(BRANCH)"
-  namespace: ocp
 tests:
 - as: none
   commands: "true"


### PR DESCRIPTION
This fixes "build org/repo#num" commands. ci-operator no longer accepts noth `tag_specification` and `releases`.

I was not able to test it fully however