### PR TITLE
Forcing chat-bot jobs to use tag_specification

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -709,7 +709,7 @@ func (m *jobManager) resolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 		}
 	}
 
-	return "", "", fmt.Errorf("unable to find a release matching %q on https://amd64.ocp.releases.ci.openshift.org or https://origin-release.svc.ci.openshift.org", imageOrVersion)
+	return "", "", fmt.Errorf("unable to find a release matching %q on https://amd64.ocp.releases.ci.openshift.org or https://amd64.origin.releases.ci.openshift.org", imageOrVersion)
 }
 
 func findNewestStableImageSpecTagBySemanticMajor(is *imagev1.ImageStream, majorMinor string) *imagev1.TagReference {

--- a/prow.go
+++ b/prow.go
@@ -420,6 +420,9 @@ func (m *jobManager) newJob(job *Job) error {
 				// delete sections we don't need
 				delete(targetConfig.Object, "tests")
 
+				// For template based jobs, we must rely on "tag_specification"
+				delete(targetConfig.Object, "releases")
+
 				if i == 0 && len(job.Inputs) > 1 {
 					targetConfig.Object["promotion"] = map[string]interface{}{
 						"name":                "stable-initial",


### PR DESCRIPTION
This fix should resolve the issues that are currently preventing the cluster-bot from being able to launch/build PR based commands.

The issue is that the underlying, template based, jobs do not support the `releases` stanza and must always use `tag_specification`.  This PR forcefully deletes the `releases` stanza from any repository configuration that it resolves from the ci-operator config.