### PR TITLE
slack: add deprecation warning for legacy launch jobs

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -1232,7 +1233,11 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 	go m.handleJobStartup(*job, "start")
 
 	if job.Mode == "launch" {
-		return "", fmt.Errorf("a cluster is being created - I'll send you the credentials in about %d minutes", m.estimateCompletion(req.RequestedAt)/time.Minute)
+		msg := fmt.Sprintf("a cluster is being created - I'll send you the credentials in about %d minutes", m.estimateCompletion(req.RequestedAt)/time.Minute)
+		if job.LegacyConfig {
+			msg = fmt.Sprintf("WARNING: using legacy template based job for this cluster. This is unsupported and the cluster may not install as expected. Contact #forum-crt for more information.\n%s", msg)
+		}
+		return "", errors.New(msg)
 	}
 	return "", fmt.Errorf("job started, you will be notified on completion")
 }

--- a/slack.go
+++ b/slack.go
@@ -363,6 +363,9 @@ func (b *Bot) jobResponder(s *slacker.Slacker) func(Job) {
 func (b *Bot) notifyJob(response slacker.ResponseWriter, job *Job) {
 	switch job.Mode {
 	case "launch":
+		if job.LegacyConfig {
+			response.Reply(fmt.Sprintf("WARNING: using legacy template based job for this cluster. This is unsupported and the cluster may not install as expected. Contact #forum-crt for more information."))
+		}
 		switch {
 		case len(job.Failure) > 0 && len(job.URL) > 0:
 			response.Reply(fmt.Sprintf("your cluster failed to launch: %s (<%s|logs>)", job.Failure, job.URL))


### PR DESCRIPTION
This PR adds a warning to users launching cluster variants for which
only legacy jobs exist.