### PR TITLE
manager,prow: support modern type tests

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -345,7 +345,7 @@ func (b *Bot) jobResponder(s *slacker.Slacker) func(Job) {
 			return
 		}
 		switch job.Mode {
-		case "launch":
+		case JobTypeLaunch:
 			if len(job.Credentials) == 0 && len(job.Failure) == 0 {
 				klog.Infof("no credentials or failure, still pending")
 				return
@@ -362,7 +362,7 @@ func (b *Bot) jobResponder(s *slacker.Slacker) func(Job) {
 
 func (b *Bot) notifyJob(response slacker.ResponseWriter, job *Job) {
 	switch job.Mode {
-	case "launch":
+	case JobTypeLaunch:
 		if job.LegacyConfig {
 			response.Reply(fmt.Sprintf("WARNING: using legacy template based job for this cluster. This is unsupported and the cluster may not install as expected. Contact #forum-crt for more information."))
 		}


### PR DESCRIPTION
This PR adds support for launching multistage based e2e tests. There are
2 ways that a test can be discovered/launched.

1. Explicitly defined tests: If a test requires an extra step in the
   `test` phase (an example would be the `baremetalds-e2e-ovn-ipsec`
   workflow), a user can define a test the same way a launch job would
   be defined, but using `e2e` as a prefix instead of `launch`.
2. Launch jobs: The vast majority of tests use just one step reference
   for their tests. Due to this, we can just take the launch job for the
   requested variant and change the `test` phase to use that step
   reference.

For configuring test types, a set of parameters/env vars are set for the
test.

This also adds the `JobTypeLaunch` const and replaces all instances of
`"launch"` being used to check the `job.Mode` with the new const.