### PR TITLE
prow: always set release:latest target

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -1224,19 +1224,12 @@ mkdir -p "$(ARTIFACTS)/initial" "$(ARTIFACTS)/final"
 cd "/home/prow/go/src"
 working_dir="$(pwd)"
 
-targets=()
+targets=("--target=[release:latest]")
 if [[ -z "${RELEASE_IMAGE_INITIAL-}" ]]; then
   unset RELEASE_IMAGE_INITIAL
-else
-  targets+=("--target=[release:initial]")
 fi
 if [[ -z "${RELEASE_IMAGE_LATEST-}" ]]; then
   unset RELEASE_IMAGE_LATEST
-else
-  targets+=("--target=[release:latest]")
-fi
-if [[ "${#targets[@]}" -eq 0 ]]; then
-  targets+=("--target=[images]")
 fi
 
 # import the initial release, if any


### PR DESCRIPTION
This ensures `release:latest`target is always set when one of the targets
requires assembling a release from PRs (`test upgrade <version> <pull-request>` or `test upgrade <pull-request> <version>`).

Example jobs:
* [test upgrade 4.9 https://github.com/openshift/cluster-config-operator/pull/222,https://github.com/openshift/machine-api-operator/pull/934 aws](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1456609425203662848)
* [test upgrade https://github.com/openshift/cluster-config-operator/pull/222,https://github.com/openshift/machine-api-operator/pull/934 4.9 gcp](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-gcp/1456613777045721088)