### PR TITLE
manager: fix build jobs

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1083,7 +1083,7 @@ func multistageParamsForPlatform(platform string) sets.String {
 func multistageNameFromParams(params map[string]string, platform, jobType string) (string, error) {
 	var prefix string
 	switch jobType {
-	case JobTypeLaunch:
+	case JobTypeLaunch, JobTypeBuild:
 		prefix = "launch"
 	case JobTypeTest:
 		prefix = "e2e"


### PR DESCRIPTION
This PR fixes an issue that causes the error "Unknown job type build",
which was case by a switch statement that did not account for the build
job type.

/cc @bradmwilliams 