### PR TITLE
allow use of upi as a launch parameter

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -60,7 +60,7 @@ var supportedUpgradeTests = []string{"e2e-upgrade", "e2e-upgrade-all", "e2e-upgr
 var supportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal", "hypershift", "ovirt", "openstack", "openstack-kuryr"}
 
 // supportedParameters are the allowed parameter keys that can be passed to jobs
-var supportedParameters = []string{"ovn", "ovn-hybrid", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt", "single-node", "cgroupsv2", "techpreview"}
+var supportedParameters = []string{"ovn", "ovn-hybrid", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv6", "preserve-bootstrap", "test", "rt", "single-node", "cgroupsv2", "techpreview", "upi"}
 
 // multistageParameters is the mapping of supportedParameters that can be configured via multistage parameters to the correct environment variable format
 var multistageParameters = map[string]envVar{


### PR DESCRIPTION
The intention of this PR is to allow use of `upi` as a launch parameter.  Initially, it is desired that this be consumable for vSphere launches(https://github.com/openshift/release/pull/23670)
