### PR TITLE
Add new IPv6 and IPv4v6 test configurations specific to metal IPI

### DIFF
--- a/prow.go
+++ b/prow.go
@@ -97,6 +97,16 @@ var envsForTestType = map[string][]envVar{
 		name:  "TEST_SUITE",
 		value: "openshift/conformance/serial",
 	}},
+	// Metal IPI specific IPv6 cluster
+	"e2e-ipv6": {{
+		name:  "TEST_SUITE",
+		value: "openshift/conformance/parallel",
+	}},
+	// Metal IPI specific IPv4v6 dualstack cluster
+	"e2e-dualstack": {{
+		name:  "TEST_SUITE",
+		value: "openshift/conformance/parallel",
+	}},
 	"e2e-all": {{
 		name:  "TEST_SUITE",
 		value: "openshift/conformance",


### PR DESCRIPTION
IPv6 and IPv4v6(dualstack) are currently only supported by metal IPI.
These tests are already being used in ci-chat-bot. However, since
they are not in `envsForTestType` list, currently ci-chat-bot returns
`unknown test type` error.