### PR TITLE
Main branch default version should be 4.10

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -655,7 +655,7 @@ func versionForRefs(refs *prowapiv1.Refs) string {
 	if refs == nil || len(refs.BaseRef) == 0 {
 		return ""
 	}
-	if refs.BaseRef == "master" {
+	if refs.BaseRef == "master" || refs.BaseRef == "main" {
 		return "4.10.0-0.latest"
 	}
 	if m := reBranchVersion.FindStringSubmatch(refs.BaseRef); m != nil {


### PR DESCRIPTION
When building image with main branch such as https://github.com/openshift/machine-api-provider-aws/pull/11, cluster-bot always build it with unexpected 4.9 build. This want to fix this issue. @bradmwilliams please help to take a look.