### PR TITLE
Workflow-upgrade jobs fixes

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -1179,7 +1179,11 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 	// try to pick a job that matches the install version, if we can, otherwise use the first that
 	// matches us (we can do better)
 	var prowJob *prowapiv1.ProwJob
-	selector := labels.Set{"job-env": req.Platform, "job-type": JobTypeLaunch} // TODO: handle versioned variants better
+	jobType := JobTypeLaunch
+	if req.Type == JobTypeWorkflowUpgrade {
+		jobType = JobTypeUpgrade
+	}
+	selector := labels.Set{"job-env": req.Platform, "job-type": jobType} // TODO: handle versioned variants better
 	if len(job.Inputs[0].Version) > 0 {
 		if v, err := semver.ParseTolerant(job.Inputs[0].Version); err == nil {
 			withRelease := labels.Merge(selector, labels.Set{"job-release": fmt.Sprintf("%d.%d", v.Major, v.Minor)})

--- a/manager.go
+++ b/manager.go
@@ -1080,7 +1080,7 @@ func (m *jobManager) resolveToJob(req *JobRequest) (*Job, error) {
 		if len(req.Platform) == 0 {
 			return nil, fmt.Errorf("platform must be set when launching clusters")
 		}
-		job.Mode = JobTypeWorkflowLaunch
+		job.Mode = JobTypeWorkflowUpgrade
 	case JobTypeWorkflowLaunch:
 		if len(jobInputs) != 1 {
 			return nil, fmt.Errorf("launching a cluster requires one image, version, or pull request")

--- a/manager.go
+++ b/manager.go
@@ -1111,6 +1111,9 @@ func multistageNameFromParams(params map[string]string, platform, jobType string
 	if jobType == JobTypeWorkflowLaunch || jobType == JobTypeBuild {
 		return "launch", nil
 	}
+	if jobType == JobTypeWorkflowUpgrade {
+		return "upgrade", nil
+	}
 	var prefix string
 	switch jobType {
 	case JobTypeLaunch:


### PR DESCRIPTION
* fix correct job.Mode so that `clusterbot-wait` would not replace the test
* unlike `workflow-launch`, these jobs should be acting as `test upgrade`
* set correct `job-type` in prowjob annotations