### PR TITLE
manager: add support for launching arm64 clusters

### DIFF
--- a/hack/run.sh
+++ b/hack/run.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 if [[ -z $BOT_TOKEN ]]; then echo "BOT_TOKEN var must be set"; exit 1; fi
+if [[ -z $BOT_APP_TOKEN ]]; then echo "BOT_APP_TOKEN var must be set"; exit 1; fi
 
 tmp_dir=$(mktemp -d)
 tmp_kk=$tmp_dir/build.kubeconfig
@@ -20,4 +21,5 @@ make
   --job-config ../release/ci-operator/jobs/openshift/release/ \
   --prow-config ../release/core-services/prow/02_config/_config.yaml \
   --build-cluster-kubeconfigs-location=$tmp_dir \
+  --workflow-config-path ../release/core-services/ci-chat-bot/workflows-config.yaml
   --v=2

--- a/manager.go
+++ b/manager.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"k8s.io/test-infra/prow/github"
 	"math"
 	"net/url"
 	"regexp"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/test-infra/prow/github"
 
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -96,7 +97,7 @@ type JobManager interface {
 	SyncJobForUser(user string) (string, error)
 	TerminateJobForUser(user string) (string, error)
 	GetLaunchJob(user string) (*Job, error)
-	LookupInputs(inputs []string) (string, error)
+	LookupInputs(inputs []string, architecture string) (string, error)
 	ListJobs(users ...string) string
 }
 
@@ -106,9 +107,10 @@ type JobCallbackFunc func(Job)
 
 // JobInput defines the input to a job. Different modes need different inputs.
 type JobInput struct {
-	Image   string
-	Version string
-	Refs    []prowapiv1.Refs
+	Image    string
+	RunImage string
+	Version  string
+	Refs     []prowapiv1.Refs
 }
 
 // Job responds to user requests and tracks the state of the launched
@@ -545,7 +547,7 @@ func (m *jobManager) ListJobs(users ...string) string {
 			}
 			switch {
 			case len(jobInput.Version) > 0:
-				inputParts = append(inputParts, fmt.Sprintf("<https://amd64.ocp.releases.ci.openshift.org/releasetag/%s|%s>", url.PathEscape(jobInput.Version), jobInput.Version))
+				inputParts = append(inputParts, fmt.Sprintf("<https://%s.ocp.releases.ci.openshift.org/releasetag/%s|%s>", job.Architecture, url.PathEscape(jobInput.Version), jobInput.Version))
 			case len(jobInput.Image) > 0:
 				inputParts = append(inputParts, "(image)")
 			}
@@ -665,77 +667,172 @@ func versionForRefs(refs *prowapiv1.Refs) string {
 
 var reMajorMinorVersion = regexp.MustCompile(`^(\d+)\.(\d+)$`)
 
-func buildPullSpec(namespace, tagName string) string {
+func buildPullSpec(namespace, tagName, archSuffix string) string {
 	var delimiter = ":"
 	if strings.HasPrefix(tagName, "sha256:") {
 		delimiter = "@"
 	}
-	return fmt.Sprintf("registry.ci.openshift.org/%s/release%s%s", namespace, delimiter, tagName)
+	return fmt.Sprintf("registry.ci.openshift.org/%s/release%s%s%s", namespace, archSuffix, delimiter, tagName)
 }
 
-func (m *jobManager) resolveImageOrVersion(imageOrVersion, defaultImageOrVersion string) (string, string, error) {
+// resolveImageOrVersion returns installSpec, tag name or version, runSpec, and error
+func (m *jobManager) resolveImageOrVersion(imageOrVersion, defaultImageOrVersion, architecture string) (string, string, string, error) {
 	if len(strings.TrimSpace(imageOrVersion)) == 0 {
 		if len(defaultImageOrVersion) == 0 {
-			return "", "", nil
+			return "", "", "", nil
 		}
 		imageOrVersion = defaultImageOrVersion
 	}
 
 	unresolved := imageOrVersion
 	if strings.Contains(unresolved, "/") {
-		return unresolved, "", nil
+		return unresolved, "", "", nil
 	}
 
-	for _, ns := range []string{"ocp", "origin"} {
-		is, err := m.imageClient.ImageV1().ImageStreams(ns).Get(context.TODO(), "release", metav1.GetOptions{})
+	imagestreams := make(map[string]string)
+	archSuffix := ""
+	switch architecture {
+	case "amd64":
+		imagestreams["ocp"] = "release"
+		imagestreams["origin"] = "release"
+	case "arm64":
+		imagestreams["ocp-arm64"] = "release-arm64"
+		archSuffix = "-arm64"
+	default:
+		return "", "", "", fmt.Errorf("Unsupported architecture: %s", architecture)
+	}
+
+	for ns, isName := range imagestreams {
+		is, err := m.imageClient.ImageV1().ImageStreams(ns).Get(context.TODO(), isName, metav1.GetOptions{})
 		if err != nil {
 			continue
 		}
 
+		var amd64IS *imagev1.ImageStream
+		if architecture != "amd64" {
+			amd64IS, err = m.imageClient.ImageV1().ImageStreams("ocp").Get(context.TODO(), "release", metav1.GetOptions{})
+			if err != nil {
+				return "", "", "", fmt.Errorf("failed to get ocp release imagstream: %w", err)
+			}
+		}
+
 		if m := reMajorMinorVersion.FindStringSubmatch(unresolved); m != nil {
-			if tag := findNewestImageSpecTagWithStream(is, fmt.Sprintf("%s.0-0.nightly", unresolved)); tag != nil {
+			if tag := findNewestImageSpecTagWithStream(is, fmt.Sprintf("%s.0-0.nightly%s", unresolved, archSuffix)); tag != nil {
 				klog.Infof("Resolved major.minor %s to nightly tag %s", imageOrVersion, tag.Name)
-				return buildPullSpec(ns, tag.Name), tag.Name, nil
+				installSpec := buildPullSpec(ns, tag.Name, archSuffix)
+				runSpec := ""
+				if architecture == "amd64" {
+					runSpec = installSpec
+				} else {
+					runTag := findNewestImageSpecTagWithStream(amd64IS, fmt.Sprintf("%s.0-0.nightly", unresolved))
+					runSpec = buildPullSpec("ocp", runTag.Name, "")
+				}
+				return installSpec, tag.Name, runSpec, nil
 			}
-			if tag := findNewestImageSpecTagWithStream(is, fmt.Sprintf("%s.0-0.ci", unresolved)); tag != nil {
+			if tag := findNewestImageSpecTagWithStream(is, fmt.Sprintf("%s.0-0.ci%s", unresolved, archSuffix)); tag != nil {
 				klog.Infof("Resolved major.minor %s to ci tag %s", imageOrVersion, tag.Name)
-				return buildPullSpec(ns, tag.Name), tag.Name, nil
+				installSpec := buildPullSpec(ns, tag.Name, archSuffix)
+				runSpec := ""
+				if architecture == "amd64" {
+					runSpec = installSpec
+				} else {
+					runTag := findNewestImageSpecTagWithStream(amd64IS, fmt.Sprintf("%s.0-0.ci", unresolved))
+					runSpec = buildPullSpec("ocp", runTag.Name, "")
+				}
+				return installSpec, tag.Name, runSpec, nil
 			}
-			if tag := findNewestStableImageSpecTagBySemanticMajor(is, unresolved); tag != nil {
+			if tag := findNewestStableImageSpecTagBySemanticMajor(is, unresolved, architecture); tag != nil {
 				klog.Infof("Resolved major.minor %s to semver tag %s", imageOrVersion, tag.Name)
-				return buildPullSpec(ns, tag.Name), tag.Name, nil
+				installSpec := buildPullSpec(ns, tag.Name, archSuffix)
+				runSpec := ""
+				if architecture == "amd64" {
+					runSpec = installSpec
+				} else {
+					runTag := findNewestImageSpecTagWithStream(amd64IS, unresolved)
+					runSpec = buildPullSpec("ocp", runTag.Name, "")
+				}
+				return installSpec, tag.Name, runSpec, nil
 			}
-			return "", "", fmt.Errorf("no stable, official prerelease, or nightly version published yet for %s", imageOrVersion)
+			return "", "", "", fmt.Errorf("no stable, official prerelease, or nightly version published yet for %s", imageOrVersion)
 		} else if unresolved == "nightly" {
-			unresolved = "4.12.0-0.nightly"
+			unresolved = fmt.Sprintf("4.12.0-0.nightly%s", archSuffix)
 		} else if unresolved == "ci" {
-			unresolved = "4.12.0-0.ci"
+			unresolved = fmt.Sprintf("4.12.0-0.ci%s", archSuffix)
 		} else if unresolved == "prerelease" {
-			unresolved = "4.12.0-0.ci"
+			unresolved = fmt.Sprintf("4.12.0-0.ci%s", archSuffix)
 		}
 
 		if tag, name := findImageStatusTag(is, unresolved); tag != nil {
 			klog.Infof("Resolved %s to image %s", imageOrVersion, tag.Image)
-			return buildPullSpec(ns, tag.Image), name, nil
+			// identify nightly stream for runspec if not amd64
+			installSpec := buildPullSpec(ns, tag.Image, archSuffix)
+			runSpec := ""
+			if architecture == "amd64" {
+				runSpec = installSpec
+			} else {
+				// if it's a nightly, just get the latest image from the nightly stream
+				if strings.Contains(unresolved, "nightly") {
+					// identify major and minor and use corresponding image
+					ver, err := semver.ParseTolerant(unresolved)
+					if err != nil {
+						return "", "", "", fmt.Errorf("failed to identify semver for image %s: %w", tag.Image, err)
+					}
+					runTag := findNewestImageSpecTagWithStream(amd64IS, fmt.Sprintf("4.%d.0-0.nightly", ver.Minor))
+					runSpec = buildPullSpec("ocp", runTag.Name, "")
+				} else {
+					runTag, _ := findImageStatusTag(amd64IS, unresolved)
+					runSpec = buildPullSpec("ocp", runTag.Image, "")
+				}
+			}
+			return installSpec, name, runSpec, nil
 		}
 
 		if tag := findNewestImageSpecTagWithStream(is, unresolved); tag != nil {
 			klog.Infof("Resolved %s to tag %s", imageOrVersion, tag.Name)
-			return buildPullSpec(ns, tag.Name), tag.Name, nil
+			// identify nightly stream for runspec if not amd64
+			installSpec := buildPullSpec(ns, tag.Name, archSuffix)
+			runSpec := ""
+			if architecture == "amd64" {
+				runSpec = installSpec
+			} else {
+				// if it's a nightly, just get the latest image from the nightly stream
+				if strings.Contains(unresolved, "nightly") {
+					// identify major and minor and use corresponding image
+					ver, err := semver.ParseTolerant(unresolved)
+					if err != nil {
+						return "", "", "", fmt.Errorf("failed to identify semver for image %s: %w", tag.Name, err)
+					}
+					runTag := findNewestImageSpecTagWithStream(amd64IS, fmt.Sprintf("4.%d.0-0.nightly", ver.Minor))
+					runSpec = buildPullSpec("ocp", runTag.Name, "")
+				} else {
+					runTag := findNewestImageSpecTagWithStream(amd64IS, unresolved)
+					runSpec = buildPullSpec("ocp", runTag.Name, "")
+				}
+			}
+			return installSpec, tag.Name, runSpec, nil
 		}
 	}
 
-	return "", "", fmt.Errorf("unable to find a release matching %q on https://amd64.ocp.releases.ci.openshift.org or https://amd64.origin.releases.ci.openshift.org", imageOrVersion)
+	errMsg := fmt.Errorf("unable to find a release matching %q on https://%s.ocp.releases.ci.openshift.org", imageOrVersion, architecture)
+	if architecture == "amd64" {
+		errMsg = fmt.Errorf("%s or https://amd64.origin.releases.ci.openshift.org", errMsg)
+	}
+
+	return "", "", "", errMsg
 }
 
-func findNewestStableImageSpecTagBySemanticMajor(is *imagev1.ImageStream, majorMinor string) *imagev1.TagReference {
+func findNewestStableImageSpecTagBySemanticMajor(is *imagev1.ImageStream, majorMinor, architecture string) *imagev1.TagReference {
 	base, err := semver.ParseTolerant(majorMinor)
 	if err != nil {
 		return nil
 	}
+	archSuffix := ""
+	if architecture == "arm64" {
+		archSuffix = "-arm64"
+	}
 	var candidates semver.Versions
 	for _, tag := range is.Spec.Tags {
-		if tag.Annotations["release.openshift.io/name"] != "4-stable" {
+		if tag.Annotations["release.openshift.io/name"] != fmt.Sprintf("4-stable%s", archSuffix) {
 			continue
 		}
 		v, err := semver.ParseTolerant(tag.Name)
@@ -789,16 +886,16 @@ func findImageStatusTag(is *imagev1.ImageStream, name string) (*imagev1.TagEvent
 	return nil, ""
 }
 
-func (m *jobManager) LookupInputs(inputs []string) (string, error) {
+func (m *jobManager) LookupInputs(inputs []string, architecture string) (string, error) {
 	// default install type jobs to "ci"
 	if len(inputs) == 0 {
-		_, version, err := m.resolveImageOrVersion("ci", "")
+		_, version, _, err := m.resolveImageOrVersion("ci", "", architecture)
 		if err != nil {
 			return "", err
 		}
 		inputs = []string{version}
 	}
-	jobInputs, err := m.lookupInputs([][]string{inputs})
+	jobInputs, err := m.lookupInputs([][]string{inputs}, architecture)
 	if err != nil {
 		return "", err
 	}
@@ -816,12 +913,12 @@ func (m *jobManager) LookupInputs(inputs []string) (string, error) {
 			out = append(out, fmt.Sprintf("`%s` uses version `%s`", inputs[i], job.Version))
 			continue
 		}
-		out = append(out, fmt.Sprintf("`%s` launches version <https://amd64.ocp.releases.ci.openshift.org/releasetag/%s|%s>", inputs[i], job.Version, job.Version))
+		out = append(out, fmt.Sprintf("`%s` launches version <https://%s.ocp.releases.ci.openshift.org/releasetag/%s|%s>", inputs[i], architecture, job.Version, job.Version))
 	}
 	return strings.Join(out, "\n"), nil
 }
 
-func (m *jobManager) lookupInputs(inputs [][]string) ([]JobInput, error) {
+func (m *jobManager) lookupInputs(inputs [][]string, architecture string) ([]JobInput, error) {
 	var jobInputs []JobInput
 
 	for _, input := range inputs {
@@ -846,7 +943,7 @@ func (m *jobManager) lookupInputs(inputs [][]string) ([]JobInput, error) {
 				}
 			} else {
 				// otherwise, resolve as a semantic version (as a tag on the release image stream) or as an image
-				image, version, err := m.resolveImageOrVersion(part, "")
+				image, version, runImage, err := m.resolveImageOrVersion(part, "", architecture)
 				if err != nil {
 					return nil, err
 				}
@@ -858,6 +955,7 @@ func (m *jobManager) lookupInputs(inputs [][]string) ([]JobInput, error) {
 				}
 				jobInput.Image = image
 				jobInput.Version = version
+				jobInput.RunImage = runImage
 			}
 		}
 		if len(jobInput.Version) == 0 && len(jobInput.Refs) > 0 {
@@ -969,19 +1067,22 @@ func (m *jobManager) resolveToJob(req *JobRequest) (*Job, error) {
 
 	// default install type jobs to "ci"
 	if len(req.Inputs) == 0 && req.Type == JobTypeInstall {
-		_, version, err := m.resolveImageOrVersion("ci", "")
+		_, version, _, err := m.resolveImageOrVersion("ci", "", job.Architecture)
 		if err != nil {
 			return nil, err
 		}
 		req.Inputs = append(req.Inputs, []string{version})
 	}
-	jobInputs, err := m.lookupInputs(req.Inputs)
+	jobInputs, err := m.lookupInputs(req.Inputs, job.Architecture)
 	if err != nil {
 		return nil, err
 	}
 
 	switch req.Type {
 	case JobTypeBuild:
+		if req.Architecture != "amd64" {
+			return nil, fmt.Errorf("builds are not currently supported for non-amd64 releases")
+		}
 		var prs int
 		for _, input := range jobInputs {
 			for _, ref := range input.Refs {
@@ -993,6 +1094,15 @@ func (m *jobManager) resolveToJob(req *JobRequest) (*Job, error) {
 		}
 		job.Mode = JobTypeBuild
 	case JobTypeInstall:
+		if req.Architecture != "amd64" {
+			for _, input := range jobInputs {
+				for _, ref := range input.Refs {
+					if len(ref.Pulls) != 0 {
+						return nil, fmt.Errorf("launching releases built from PRs is not currently supported for non-amd64 releases")
+					}
+				}
+			}
+		}
 		if len(jobInputs) != 1 {
 			return nil, fmt.Errorf("launching a cluster requires one image, version, or pull request")
 		}
@@ -1001,6 +1111,9 @@ func (m *jobManager) resolveToJob(req *JobRequest) (*Job, error) {
 		}
 		job.Mode = JobTypeLaunch
 	case JobTypeUpgrade:
+		if req.Architecture != "amd64" {
+			return nil, fmt.Errorf("upgrade tests are not currently supported for non-amd64 releases")
+		}
 		if len(jobInputs) != 2 {
 			return nil, fmt.Errorf("upgrading a cluster requires two images, versions, or pull requests")
 		}
@@ -1012,6 +1125,9 @@ func (m *jobManager) resolveToJob(req *JobRequest) (*Job, error) {
 			return nil, fmt.Errorf("a test type is required for upgrading, default is e2e-upgrade")
 		}
 	case JobTypeTest:
+		if req.Architecture != "amd64" {
+			return nil, fmt.Errorf("tests are not currently supported for non-amd64 releases")
+		}
 		if len(jobInputs) != 1 {
 			return nil, fmt.Errorf("launching a cluster requires one image, version, or pull request")
 		}
@@ -1023,6 +1139,9 @@ func (m *jobManager) resolveToJob(req *JobRequest) (*Job, error) {
 		}
 		job.Mode = JobTypeTest
 	case JobTypeWorkflowUpgrade:
+		if req.Architecture != "amd64" {
+			return nil, fmt.Errorf("workflow upgrades are not currently supported for non-amd64 releases")
+		}
 		if len(jobInputs) != 2 {
 			return nil, fmt.Errorf("upgrade test requires two images, versions, or pull requests")
 		}
@@ -1031,6 +1150,9 @@ func (m *jobManager) resolveToJob(req *JobRequest) (*Job, error) {
 		}
 		job.Mode = JobTypeWorkflowUpgrade
 	case JobTypeWorkflowLaunch:
+		if req.Architecture != "amd64" {
+			return nil, fmt.Errorf("workflow launches are not currently supported for non-amd64 releases")
+		}
 		if len(jobInputs) != 1 {
 			return nil, fmt.Errorf("launching a cluster requires one image, version, or pull request")
 		}
@@ -1132,7 +1254,7 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 	if req.Type == JobTypeWorkflowUpgrade {
 		jobType = JobTypeUpgrade
 	}
-	selector := labels.Set{"job-env": req.Platform, "job-type": jobType} // TODO: handle versioned variants better
+	selector := labels.Set{"job-env": req.Platform, "job-type": jobType, "job-architecture": req.Architecture} // TODO: handle versioned variants better
 	if len(job.Inputs[0].Version) > 0 {
 		if v, err := semver.ParseTolerant(job.Inputs[0].Version); err == nil {
 			withRelease := labels.Merge(selector, labels.Set{"job-release": fmt.Sprintf("%d.%d", v.Major, v.Minor)})
@@ -1144,7 +1266,7 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 		// Currently, there is an important difference between the template e2e-upgrade-all test and what can be done with the step-registry tests.
 		// For now, fallback to templates for this test until this difference can be resolved.
 		if test := job.JobParams["test"]; test != "e2e-upgrade-all" {
-			primarySelector := labels.Set{"job-env": req.Platform, "job-type": JobTypeLaunch, "config-type": "modern"} // these jobs will only contain configs using non-deprecated features
+			primarySelector := labels.Set{"job-env": req.Platform, "job-type": JobTypeLaunch, "config-type": "modern", "job-architecture": job.Architecture} // these jobs will only contain configs using non-deprecated features
 			prowJob, _ = prow.JobForLabels(m.prowConfigLoader, labels.SelectorFromSet(primarySelector))
 			if prowJob != nil {
 				if sourceEnv, _, ok := firstEnvVar(prowJob.Spec.PodSpec, "UNRESOLVED_CONFIG"); ok { // all multistage configs will be unresolved
@@ -1155,7 +1277,7 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 				}
 			}
 		}
-		if !primaryHasVariant {
+		if !primaryHasVariant && req.Architecture == "amd64" { // only support legacy templates for amd64 arch
 			job.LegacyConfig = true
 			fallbackSelector := labels.Set{"job-env": req.Platform, "job-type": JobTypeLaunch, "config-type": "legacy"} // these jobs will contain older, deprecated configs that can be used as fallback for the primary config typr
 			prowJob, _ = prow.JobForLabels(m.prowConfigLoader, labels.SelectorFromSet(fallbackSelector))

--- a/prow.go
+++ b/prow.go
@@ -187,7 +187,7 @@ func testStepForPlatform(platform string) string {
 }
 
 // supportedArchitectures are the allowed architectures that can be passed to jobs
-var supportedArchitectures = []string{"amd64"}
+var supportedArchitectures = []string{"amd64", "arm64"}
 
 var (
 	// reReleaseVersion detects whether a branch appears to correlate to a release branch
@@ -394,17 +394,35 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 	var restoreImageVariableScript []string
 	lastJobInput := len(job.Inputs) - 1
 	image := job.Inputs[lastJobInput].Image
+	runImage := job.Inputs[lastJobInput].RunImage
 	var initialImage string
 	if len(job.Inputs) > 1 {
 		initialImage = job.Inputs[0].Image
 		if len(job.Inputs[0].Refs) == 0 && len(initialImage) > 0 {
 			restoreImageVariableScript = append(restoreImageVariableScript, fmt.Sprintf("RELEASE_IMAGE_INITIAL=%s", initialImage))
 		}
-		if len(job.Inputs[lastJobInput].Refs) == 0 && len(image) > 0 {
-			restoreImageVariableScript = append(restoreImageVariableScript, fmt.Sprintf("RELEASE_IMAGE_LATEST=%s", image))
+		if len(job.Inputs[lastJobInput].Refs) == 0 && len(runImage) > 0 {
+			restoreImageVariableScript = append(restoreImageVariableScript, fmt.Sprintf("RELEASE_IMAGE_LATEST=%s", runImage))
 		}
 	}
-	prow.OverrideJobEnvironment(&pj.Spec, image, initialImage, targetRelease, namespace, variants)
+	prow.OverrideJobEnvironment(&pj.Spec, runImage, initialImage, targetRelease, namespace, variants)
+
+	if job.Architecture == "arm64" {
+		for i := range pj.Spec.PodSpec.Containers {
+			c := &pj.Spec.PodSpec.Containers[i]
+			exists := false
+			for j := range c.Env {
+				switch name := c.Env[j].Name; name {
+				case "RELEASE_IMAGE_ARM64_LATEST":
+					exists = true
+					c.Env[j].Value = image
+				}
+			}
+			if !exists {
+				c.Env = append(c.Env, corev1.EnvVar{Name: "RELEASE_IMAGE_ARM64_LATEST", Value: image})
+			}
+		}
+	}
 
 	// find the ci-operator config for the job we will run
 	sourceEnv, _, ok := firstEnvVar(pj.Spec.PodSpec, "CONFIG_SPEC")
@@ -561,6 +579,17 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 					IncludeBuiltImages: true,
 				},
 			},
+		}
+		if job.Architecture == "arm64" {
+			sourceConfig.Releases["arm64-latest"] = citools.UnresolvedRelease{
+				// as this just gets overridden by the env var, the actual details here don't matter
+				Candidate: &citools.Candidate{
+					Architecture: "arm64",
+					Product:      "ocp",
+					Stream:       "nightly",
+					Version:      "4.12",
+				},
+			}
 		}
 		sourceConfig.ReleaseTagConfiguration = nil
 	}

--- a/slack.go
+++ b/slack.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/shomali11/slacker"
 	"github.com/slack-go/slack"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/klog"
 	prowapiv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -109,7 +110,7 @@ func (b *Bot) Start(manager JobManager) error {
 		},
 	})
 
-	client.Command("lookup <image_or_version_or_pr>", &slacker.CommandDefinition{
+	client.Command("lookup <image_or_version_or_pr> <architecture>", &slacker.CommandDefinition{
 		Description: "Get info about a version.",
 		Handler: func(botCtx slacker.BotContext, request slacker.Request, response slacker.ResponseWriter) {
 			from, err := parseImageInput(request.StringParam("image_or_version_or_pr", ""))
@@ -117,7 +118,22 @@ func (b *Bot) Start(manager JobManager) error {
 				b.reply(response, err.Error())
 				return
 			}
-			msg, err := manager.LookupInputs(from)
+			architectureRaw, err := parseImageInput(request.StringParam("architecture", ""))
+			if err != nil {
+				b.reply(response, err.Error())
+				return
+			} else if len(architectureRaw) > 1 {
+				b.reply(response, "Error: cannot specify more than one architecture for this command")
+				return
+			}
+			architecture := "amd64" // default arch
+			if len(architectureRaw) == 1 {
+				architecture = architectureRaw[0]
+			}
+			if !sets.NewString(supportedArchitectures...).Has(architecture) {
+				b.reply(response, fmt.Sprintf("Error: %s is an invalid architecture. Supported architectures: %v", architecture, supportedArchitectures))
+			}
+			msg, err := manager.LookupInputs(from, architecture)
 			if err != nil {
 				b.reply(response, err.Error())
 				return


### PR DESCRIPTION
This PR adds support for launching arm64 clusters by adding `arm64` to
the options list.