### PR TITLE
Allow for users to specify a fully-qualified image

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -956,6 +956,9 @@ func (m *jobManager) lookupInputs(inputs [][]string, architecture string) ([]Job
 				if len(jobInput.Image) > 0 {
 					return nil, fmt.Errorf("only one image or version may be specified in a list of installs")
 				}
+				if architecture == "arm64" && (len(runImage) == 0 || len(version) == 0) {
+					return nil, fmt.Errorf("only version numbers (like: 4.11.0) may be used for arm64 based clusters")
+				}
 				jobInput.Image = image
 				jobInput.Version = version
 				jobInput.RunImage = runImage

--- a/prow.go
+++ b/prow.go
@@ -396,6 +396,7 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 	var restoreImageVariableScript []string
 	lastJobInput := len(job.Inputs) - 1
 	image := job.Inputs[lastJobInput].Image
+	version := job.Inputs[lastJobInput].Version
 	runImage := job.Inputs[lastJobInput].RunImage
 	var initialImage string
 	if len(job.Inputs) > 1 {
@@ -407,7 +408,12 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 			restoreImageVariableScript = append(restoreImageVariableScript, fmt.Sprintf("RELEASE_IMAGE_LATEST=%s", runImage))
 		}
 	}
-	prow.OverrideJobEnvironment(&pj.Spec, runImage, initialImage, targetRelease, namespace, variants)
+
+	if len(image) > 0 && len(version) == 0 && len(runImage) == 0 {
+		prow.OverrideJobEnvironment(&pj.Spec, image, initialImage, targetRelease, namespace, variants)
+	} else {
+		prow.OverrideJobEnvironment(&pj.Spec, runImage, initialImage, targetRelease, namespace, variants)
+	}
 
 	if job.Architecture == "arm64" {
 		for i := range pj.Spec.PodSpec.Containers {


### PR DESCRIPTION
We recently regressed the ability for users to specify fully qualified images:
`launch registry.ci.openshift.org/ocp/release:4.12.0-0.ci-2022-08-18-183252`

This PR restores that functionality.