### PR TITLE
OCPCRT-154: manager: add support for multiarch images

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -709,8 +709,6 @@ func (m *jobManager) resolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 		// the release-controller cannot assemble multi-arch release, so we must use the `art-latest` streams instead of `release-multi`
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp-multi", Imagestream: "4.12-art-latest-multi", ArchSuffix: "-multi"})
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp-multi", Imagestream: "4.11-art-latest-multi", ArchSuffix: "-multi"})
-		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp-multi", Imagestream: "4.10-art-latest-multi", ArchSuffix: "-multi"})
-		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp-multi", Imagestream: "4.9-art-latest-multi", ArchSuffix: "-multi"})
 	default:
 		return "", "", "", fmt.Errorf("Unsupported architecture: %s", architecture)
 	}

--- a/prow.go
+++ b/prow.go
@@ -189,7 +189,7 @@ func testStepForPlatform(platform string) string {
 }
 
 // supportedArchitectures are the allowed architectures that can be passed to jobs
-var supportedArchitectures = []string{"amd64", "arm64"}
+var supportedArchitectures = []string{"amd64", "arm64", "multi"}
 
 var (
 	// reReleaseVersion detects whether a branch appears to correlate to a release branch

--- a/slack.go
+++ b/slack.go
@@ -768,7 +768,7 @@ func parseOptions(options string) (string, string, map[string]string, error) {
 		switch architecture {
 		case "amd64":
 			platform = "gcp"
-		case "arm64":
+		case "arm64", "multi":
 			platform = "aws"
 		default:
 			return "", "", nil, fmt.Errorf("unknown architecture: %s", architecture)


### PR DESCRIPTION
This PR adds support for launching clusters using multiarch images from
https://multi.ocp.releases.ci.openshift.org. Clusters that use multiarch
images are launched on `amd64` based nodes and thus use the `amd64`
launch jobs.