### PR TITLE
add a retry mechanism for PostMessage

### DIFF
--- a/eventHandler.go
+++ b/eventHandler.go
@@ -62,7 +62,6 @@ func postResponse(client *slack.Client, event *slackevents.MessageEvent, respons
 	err := wait.PollImmediate(5*time.Second, 20*time.Second, func() (bool, error) {
 		_, responseTimestamp, err := client.PostMessage(event.Channel, slack.MsgOptionText(response, false))
 		if err != nil {
-			klog.Errorf("Failed to post response to UserID: %s; (event: `%s`) at %d; %v", event.User, event.Text, (time.Now()).Unix(), err)
 			lastErr = err
 			return false, nil
 		}
@@ -70,6 +69,7 @@ func postResponse(client *slack.Client, event *slackevents.MessageEvent, respons
 		return true, nil
 	})
 	if err != nil {
+		klog.Errorf("Failed to post response to UserID: %s; (event: `%s`) at %d; %v", event.User, event.Text, (time.Now()).Unix(), err)
 		return lastErr
 	}
 	return nil


### PR DESCRIPTION
On certain occasions (very rarely), posting a response to the requestor fails (non-client-related reasons). 
This PR adds a retry for posting the response to the requestor. 