### PR TITLE
slack: Make it easier to self-help workflow-launch failures

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/klog"
 	"math/rand"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -220,7 +221,12 @@ func getPlatformArchFromWorkflowConfig(workflowConfig *WorkflowConfig, name stri
 	workflowConfig.mutex.RLock()
 	defer workflowConfig.mutex.RUnlock()
 	if workflow, ok := workflowConfig.Workflows[name]; !ok {
-		return "", "", fmt.Errorf("Workflow %s not in workflow list. Please add %s to the workflows list before retrying this command", name, name)
+		workflows := make([]string, 0, len(workflowConfig.Workflows))
+		for w := range workflowConfig.Workflows {
+			workflows = append(workflows, w)
+		}
+		sort.Strings(workflows)
+		return "", "", fmt.Errorf("Workflow %s not in workflow list ( https://github.com/openshift/release/blob/master/core-services/ci-chat-bot/workflows-config.yaml ). Please add %s to the workflows list before retrying this command, or use a workflow from: %s", name, name, strings.Join(workflows, ", "))
 	} else {
 		platform = workflow.Platform
 		if workflow.Architecture != "" {


### PR DESCRIPTION
By listing known workloads and pointing folks at where they can (hopefully) add more.  Assuming the config comes from the release repo is brittle, but since we're probably the only folks running this thing, it may help.  I guess we could also add an explicit config knob for "where to suggest changes to this config", but I'm punting on that for now.