### PR TITLE
manager,prow: add optional operator support

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -155,6 +155,8 @@ type Job struct {
 	WorkflowName string
 
 	UseSecondaryAccount bool
+
+	IsOperator bool
 }
 
 func (j Job) IsComplete() bool {
@@ -1460,7 +1462,12 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 	}
 
 	if job.Mode == JobTypeLaunch || job.Mode == JobTypeWorkflowLaunch {
-		msg = fmt.Sprintf("%sa <%s|cluster is being created> - I'll send you the credentials in about %d minutes", msg, prowJobUrl, m.estimateCompletion(req.RequestedAt)/time.Minute)
+		msg = fmt.Sprintf("%sa <%s|cluster is being created>", msg, prowJobUrl)
+		if job.IsOperator {
+			msg = fmt.Sprintf("%s - On completion of the creation of the cluster, your optional operator will begin installation. I'll send you the credentials once both the cluster and the operator are ready", msg)
+		} else {
+			msg = fmt.Sprintf("%s - I'll send you the credentials in about %d minutes", msg, m.estimateCompletion(req.RequestedAt)/time.Minute)
+		}
 		return "", errors.New(msg)
 	}
 	return "", fmt.Errorf("%s<%s|job> started, you will be notified on completion", msg, prowJobUrl)

--- a/prow.go
+++ b/prow.go
@@ -752,19 +752,15 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 						if targetConfig.Operator.Bundles[0].As != "" {
 							indexName = fmt.Sprintf("ci-index-%s", targetConfig.Operator.Bundles[0].As)
 						}
-						klog.V(2).Infof("Searching for environment")
 					TestLoop:
 						for _, test := range targetConfig.Tests {
-							klog.V(2).Infof("Looking at test %s", test.As)
 							// since we retrieved the config from the resolver, the tests are fully resolved "literal" configurations
 							if test.MultiStageTestConfigurationLiteral != nil {
 								// fully resolved configs more all dependency and environment declarations to the step instead of global setting
 								for _, step := range test.MultiStageTestConfigurationLiteral.Pre {
 									// dependency naming is deterministic, so we can use that to search for the correct test
 									for _, env := range step.Dependencies {
-										klog.V(2).Infof("Looking at dependency %s/%s in test %s", env.Env, env.Name, test.As)
 										if env.Env == "OO_INDEX" && env.Name == indexName {
-											klog.V(2).Infof("Found env vars for bundle with index %s: %v", indexName, step.Environment)
 											environment = step.Environment
 											break TestLoop
 										}
@@ -779,7 +775,6 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 										continue
 									}
 									sourceConfig.Tests[index].MultiStageTestConfiguration.Environment[env.Name] = *env.Default
-									klog.V(2).Infof("Added %s/%s env var", env.Name, *env.Default)
 								}
 								if sourceConfig.Tests[index].MultiStageTestConfiguration.Dependencies == nil {
 									sourceConfig.Tests[index].MultiStageTestConfiguration.Dependencies = make(citools.TestDependencies)
@@ -808,23 +803,6 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 								Name:      "stable",
 								Tag:       string(image.To),
 								Namespace: "$(NAMESPACE)",
-							}
-						}
-						// make sure base image for base index is available
-						if targetConfig.Operator.Bundles[0].BaseIndex != "" {
-							var baseHasIndex bool
-							for name := range sourceConfig.BaseImages {
-								if name == targetConfig.Operator.Bundles[0].BaseIndex {
-									baseHasIndex = true
-									break
-								}
-							}
-							if !baseHasIndex {
-								for name, image := range targetConfig.BaseImages {
-									if name == targetConfig.Operator.Bundles[0].BaseIndex {
-										sourceConfig.BaseImages[name] = image
-									}
-								}
 							}
 						}
 					}

--- a/prow.go
+++ b/prow.go
@@ -712,6 +712,8 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 		}
 
 		index := 0
+		// we can only support one operator bundle build, so we need to know if other bundles may be declared here
+		operatorRepo := ""
 		for i, input := range job.Inputs {
 			for _, ref := range input.Refs {
 				configData, ok, err := m.configResolver.Resolve(ref.Org, ref.Repo, ref.BaseRef, "")
@@ -730,6 +732,102 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 				if klog.V(2) {
 					data, _ := json.MarshalIndent(targetConfig, "", "  ")
 					klog.Infof("Found target job config:\n%s", string(data))
+				}
+
+				if targetConfig.Operator != nil && len(targetConfig.Operator.Bundles) > 0 {
+					if len(targetConfig.Operator.Bundles) > 1 {
+						return "", fmt.Errorf("multiple operator bundles are defined for repo %s; this is not currently supported", fmt.Sprintf("%s/%s", ref.Org, ref.Repo))
+					}
+					if job.IsOperator {
+						if operatorRepo != fmt.Sprintf("%s/%s", ref.Org, ref.Repo) {
+							return "", fmt.Errorf("multiple operator sources were configured; this is not currently supported")
+						}
+					} else {
+						operatorRepo = fmt.Sprintf("%s/%s", ref.Org, ref.Repo)
+						job.IsOperator = true
+						sourceConfig.Operator = targetConfig.Operator
+						// find test definition referencing the bundle for dependencies and environment
+						var environment []citools.StepParameter
+						indexName := "ci-index"
+						if targetConfig.Operator.Bundles[0].As != "" {
+							indexName = fmt.Sprintf("ci-index-%s", targetConfig.Operator.Bundles[0].As)
+						}
+						klog.V(2).Infof("Searching for environment")
+					TestLoop:
+						for _, test := range targetConfig.Tests {
+							klog.V(2).Infof("Looking at test %s", test.As)
+							// since we retrieved the config from the resolver, the tests are fully resolved "literal" configurations
+							if test.MultiStageTestConfigurationLiteral != nil {
+								// fully resolved configs more all dependency and environment declarations to the step instead of global setting
+								for _, step := range test.MultiStageTestConfigurationLiteral.Pre {
+									// dependency naming is deterministic, so we can use that to search for the correct test
+									for _, env := range step.Dependencies {
+										klog.V(2).Infof("Looking at dependency %s/%s in test %s", env.Env, env.Name, test.As)
+										if env.Env == "OO_INDEX" && env.Name == indexName {
+											klog.V(2).Infof("Found env vars for bundle with index %s: %v", indexName, step.Environment)
+											environment = step.Environment
+											break TestLoop
+										}
+									}
+								}
+							}
+						}
+						for index, test := range sourceConfig.Tests {
+							if test.As == "launch" {
+								for _, env := range environment {
+									if !strings.HasPrefix(env.Name, "OO") {
+										continue
+									}
+									sourceConfig.Tests[index].MultiStageTestConfiguration.Environment[env.Name] = *env.Default
+									klog.V(2).Infof("Added %s/%s env var", env.Name, *env.Default)
+								}
+								if sourceConfig.Tests[index].MultiStageTestConfiguration.Dependencies == nil {
+									sourceConfig.Tests[index].MultiStageTestConfiguration.Dependencies = make(citools.TestDependencies)
+								}
+								sourceConfig.Tests[index].MultiStageTestConfiguration.Dependencies["OO_INDEX"] = indexName
+								if len(test.MultiStageTestConfiguration.Test) == 0 {
+									testStep := testStepForPlatform(job.Platform)
+									test.MultiStageTestConfiguration.Test = []citools.TestStep{{Reference: &testStep}}
+								}
+								subscribe := "optional-operators-subscribe"
+								test.MultiStageTestConfiguration.Test = append([]citools.TestStep{{Reference: &subscribe}}, test.MultiStageTestConfiguration.Test...)
+							}
+						}
+						// specify root
+						sourceConfig.BuildRootImage = targetConfig.BuildRootImage
+						// specify base_images
+						if len(targetConfig.BaseImages) > 0 && sourceConfig.BaseImages == nil {
+							sourceConfig.BaseImages = make(map[string]citools.ImageStreamTagReference)
+						}
+						for name, ref := range targetConfig.BaseImages {
+							sourceConfig.BaseImages[name] = ref
+						}
+						// the `operator` stanza needs the built images to be in `pipeline`. This is a hacky way to acheieve that
+						for _, image := range targetConfig.Images {
+							sourceConfig.BaseImages[string(image.To)] = citools.ImageStreamTagReference{
+								Name:      "stable",
+								Tag:       string(image.To),
+								Namespace: "$(NAMESPACE)",
+							}
+						}
+						// make sure base image for base index is available
+						if targetConfig.Operator.Bundles[0].BaseIndex != "" {
+							var baseHasIndex bool
+							for name := range sourceConfig.BaseImages {
+								if name == targetConfig.Operator.Bundles[0].BaseIndex {
+									baseHasIndex = true
+									break
+								}
+							}
+							if !baseHasIndex {
+								for name, image := range targetConfig.BaseImages {
+									if name == targetConfig.Operator.Bundles[0].BaseIndex {
+										sourceConfig.BaseImages[name] = image
+									}
+								}
+							}
+						}
+					}
 				}
 
 				// delete sections we don't need
@@ -1105,15 +1203,21 @@ func (m *jobManager) waitForJob(job *Job) error {
 			if prowJobPod.Status.Phase == "Succeeded" || prowJobPod.Status.Phase == "Failed" {
 				return false, errJobCompleted
 			}
-			launchSecret, err := clusterClient.CoreClient.CoreV1().Secrets(namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
+			secretDir, err := clusterClient.CoreClient.CoreV1().Secrets(namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
 			if err != nil {
 				// It will take awhile before the secret is established and for the ci-chat-bot serviceaccount
 				// to get permission to access it (see openshift-cluster-bot-rbac step). Ignore errors.
 				return false, nil
 			}
-			if _, ok := launchSecret.Data["console.url"]; ok {
+			if _, ok := secretDir.Data["console.url"]; ok {
 				// If the console.url is established, the cluster was setup.
-				return true, nil
+				if job.IsOperator {
+					if _, ok := secretDir.Data["oo_deployment_details.yaml"]; ok {
+						return true, nil
+					}
+				} else {
+					return true, nil
+				}
 			}
 			return false, nil
 		} else {
@@ -1164,9 +1268,9 @@ func (m *jobManager) waitForJob(job *Job) error {
 	}
 
 	if stepBasedMode {
-		launchSecret, err := clusterClient.CoreClient.CoreV1().Secrets(namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
+		secretDir, err := clusterClient.CoreClient.CoreV1().Secrets(namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
 		if err == nil {
-			if content, ok := launchSecret.Data["kubeconfig"]; ok {
+			if content, ok := secretDir.Data["kubeconfig"]; ok {
 				kubeconfig = string(content)
 			} else {
 				klog.Errorf("job %q unable to find kubeconfig entry in step secret in %s/%s", job.Name, namespace, targetName)
@@ -1216,18 +1320,22 @@ func (m *jobManager) waitForJob(job *Job) error {
 	}
 
 	var kubeadminPassword string
+	var operatorDeploymentInfo string
 	if stepBasedMode {
-		launchSecret, err := clusterClient.CoreClient.CoreV1().Secrets(namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
+		secretDir, err := clusterClient.CoreClient.CoreV1().Secrets(namespace).Get(context.TODO(), targetName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to retrieve step secret %s/%s: %v", namespace, targetName, err)
 		}
-		if consoleURL, ok := launchSecret.Data["console.url"]; ok {
+		if consoleURL, ok := secretDir.Data["console.url"]; ok {
 			job.PasswordSnippet = string(consoleURL)
 		} else {
 			return fmt.Errorf("unable to retrieve console.url from step secret %s/%s", namespace, targetName)
 		}
-		if password, ok := launchSecret.Data["kubeadmin-password"]; ok {
+		if password, ok := secretDir.Data["kubeadmin-password"]; ok {
 			kubeadminPassword = string(password)
+		}
+		if deployment, ok := secretDir.Data["oo_deployment_details.yaml"]; ok {
+			operatorDeploymentInfo = string(deployment)
 		}
 	} else {
 		lines := int64(2)
@@ -1250,6 +1358,9 @@ func (m *jobManager) waitForJob(job *Job) error {
 
 	if len(kubeadminPassword) > 0 {
 		job.PasswordSnippet += fmt.Sprintf("\nLog in to the console with user `kubeadmin` and password `%s`", kubeadminPassword)
+		if len(operatorDeploymentInfo) > 0 {
+			job.PasswordSnippet += fmt.Sprintf("\nThis following is the deployment information for you operator:\n%s", operatorDeploymentInfo)
+		}
 	} else {
 		job.PasswordSnippet = fmt.Sprintf("\nError: Unable to retrieve kubeadmin password, you must use the kubeconfig file to access the cluster")
 	}
@@ -1457,6 +1568,7 @@ mkdir -p "$(ARTIFACTS)/initial" "$(ARTIFACTS)/final"
 
 # HACK: clonerefs infers a directory from the refs provided to the prowjob, there's no way
 # to override it outside the job today, so simply reset to the working dir
+initial_dir=$(pwd)
 cd "/home/prow/go/src"
 working_dir="$(pwd)"
 
@@ -1509,6 +1621,7 @@ done
 
 # drain the job results
 for i in ${pids[@]}; do if ! wait $i; then exit 1; fi; done
+cd ${initial_dir}
 `
 
 const permissionsScript = `

--- a/prow.go
+++ b/prow.go
@@ -1076,6 +1076,8 @@ func (m *jobManager) waitForJob(job *Job) error {
 	setupContainerTimeout := 60 * time.Minute
 	if job.Platform == "metal" {
 		setupContainerTimeout = 90 * time.Minute
+	} else if job.IsOperator {
+		setupContainerTimeout = 105 * time.Minute
 	}
 
 	if job.Mode != JobTypeLaunch && job.Mode != JobTypeWorkflowLaunch {


### PR DESCRIPTION
This PR adds the ability for users to provide a PR to an optional operator repo and build and install the operator from that repo to a cluster launched by the cluster-bot.