### PR TITLE
manager: use first bundle from multi-bundle config

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/openshift/ci-chat-bot/pkg/prow"
-	"github.com/openshift/ci-chat-bot/pkg/utils"
 	"math"
 	"net/url"
 	"regexp"
@@ -15,6 +13,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/ci-chat-bot/pkg/prow"
+	"github.com/openshift/ci-chat-bot/pkg/utils"
 
 	"k8s.io/test-infra/prow/github"
 
@@ -1296,7 +1297,11 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 	if job.Mode == JobTypeLaunch || job.Mode == JobTypeWorkflowLaunch {
 		msg = fmt.Sprintf("%sa <%s|cluster is being created>", msg, prowJobUrl)
 		if job.IsOperator {
-			msg = fmt.Sprintf("%s - On completion of the creation of the cluster, your optional operator will begin installation. I'll send you the credentials once both the cluster and the operator are ready", msg)
+			msg = fmt.Sprintf("%s - On completion of the creation of the cluster, your optional operator will begin installation", msg)
+			if job.OperatorBundleName != "" {
+				msg = fmt.Sprintf("%s using the configuration for the `%s` bundle", msg, job.OperatorBundleName)
+			}
+			msg = fmt.Sprintf("%s. I'll send you the credentials once both the cluster and the operator are ready", msg)
 		} else {
 			msg = fmt.Sprintf("%s - I'll send you the credentials in about %d minutes", msg, m.estimateCompletion(req.RequestedAt)/time.Minute)
 		}

--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -7,8 +7,6 @@ import (
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/ci-chat-bot/pkg/prow"
-	"github.com/openshift/ci-chat-bot/pkg/utils"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -20,6 +18,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/openshift/ci-chat-bot/pkg/prow"
+	"github.com/openshift/ci-chat-bot/pkg/utils"
 
 	"k8s.io/klog"
 	"sigs.k8s.io/yaml"
@@ -720,9 +721,6 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 				}
 
 				if targetConfig.Operator != nil && len(targetConfig.Operator.Bundles) > 0 {
-					if len(targetConfig.Operator.Bundles) > 1 {
-						return "", fmt.Errorf("multiple operator bundles are defined for repo %s; this is not currently supported", fmt.Sprintf("%s/%s", ref.Org, ref.Repo))
-					}
 					if job.IsOperator {
 						if operatorRepo != fmt.Sprintf("%s/%s", ref.Org, ref.Repo) {
 							return "", fmt.Errorf("multiple operator sources were configured; this is not currently supported")
@@ -736,6 +734,7 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 						indexName := "ci-index"
 						if targetConfig.Operator.Bundles[0].As != "" {
 							indexName = fmt.Sprintf("ci-index-%s", targetConfig.Operator.Bundles[0].As)
+							job.OperatorBundleName = targetConfig.Operator.Bundles[0].As
 						}
 					TestLoop:
 						for _, test := range targetConfig.Tests {

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -1,6 +1,10 @@
 package manager
 
 import (
+	"net/url"
+	"sync"
+	"time"
+
 	"github.com/openshift/ci-chat-bot/pkg/prow"
 	"github.com/openshift/ci-chat-bot/pkg/utils"
 	citools "github.com/openshift/ci-tools/pkg/api"
@@ -10,9 +14,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	prowapiv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/github"
-	"net/url"
-	"sync"
-	"time"
 )
 
 type envVar struct {
@@ -185,5 +186,6 @@ type Job struct {
 
 	UseSecondaryAccount bool
 
-	IsOperator bool
+	IsOperator         bool
+	OperatorBundleName string
 }


### PR DESCRIPTION
This PR allows users to launch an operator in repos that define more than one bundle in their configuration. It will take the first bundle in the list and inform the user what bundle name/config is being used. This should only be a temporary measure; in the future, users should be able to specify which bundle they want from the ones defined in the config.