### PR TITLE
bump test-infra to revision dfec9ce18ddd3133a675759e61f11befa735c428

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/klog v1.0.0
-	k8s.io/test-infra v0.0.0-20221109051814-e69c5f8e8435
+	k8s.io/test-infra v0.0.0-20221121175430-dfec9ce18ddd
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/yaml v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2407,8 +2407,8 @@ k8s.io/test-infra v0.0.0-20200514184223-ba32c8aae783/go.mod h1:bW6thaPZfL2hW7ecj
 k8s.io/test-infra v0.0.0-20200617221206-ea73eaeab7ff/go.mod h1:L3+cRvwftUq8IW1TrHji5m3msnc4uck/7LsE/GR/aZk=
 k8s.io/test-infra v0.0.0-20200630233406-1dca6122872e/go.mod h1:L3+cRvwftUq8IW1TrHji5m3msnc4uck/7LsE/GR/aZk=
 k8s.io/test-infra v0.0.0-20210730160938-8ad9b8c53bd8/go.mod h1:RXgSaKbQA0upN4GGyH38yRkotDJr3myiKWkvdfB5yP4=
-k8s.io/test-infra v0.0.0-20221109051814-e69c5f8e8435 h1:KUqxiZVs7rvGZPN2j/PXpsDn5o0L+yEGr2EI2IkdmiY=
-k8s.io/test-infra v0.0.0-20221109051814-e69c5f8e8435/go.mod h1:LrZ9PXzfL7BKpnjk28oSvx7YFPGzNt4PTCoCSj7UTEI=
+k8s.io/test-infra v0.0.0-20221121175430-dfec9ce18ddd h1:iyapUCqegLrDnkvXzycyP6BpD14I3ViOavaNdSU/jWw=
+k8s.io/test-infra v0.0.0-20221121175430-dfec9ce18ddd/go.mod h1:LrZ9PXzfL7BKpnjk28oSvx7YFPGzNt4PTCoCSj7UTEI=
 k8s.io/utils v0.0.0-20181019225348-5e321f9a457c/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/vendor/k8s.io/test-infra/prow/config/jobs.go
+++ b/vendor/k8s.io/test-infra/prow/config/jobs.go
@@ -175,7 +175,7 @@ type Presubmit struct {
 	// Brancher matches.
 	// This is used when a prowjob is so expensive that it's not ideal to run on
 	// every single push from all PRs.
-	RunBeforeMerge bool `json:"run_before_merge"`
+	RunBeforeMerge bool `json:"run_before_merge,omitempty"`
 
 	Brancher
 

--- a/vendor/k8s.io/test-infra/prow/git/v2/remote.go
+++ b/vendor/k8s.io/test-infra/prow/git/v2/remote.go
@@ -147,7 +147,7 @@ func (f *pathResolverFactory) PublishRemote(org, repo string) RemoteResolver {
 	}
 }
 
-// gerritResolverFactory is meant to be used by Gerrit only. It's so diffrent
+// gerritResolverFactory is meant to be used by Gerrit only. It's so different
 // from GitHub that there is no way any of the remotes logic can be shared
 // between these two providers. The resulting CentralRemote and PublishRemote
 // are both the clone URI.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -957,7 +957,7 @@ k8s.io/kube-openapi/pkg/schemamutation
 k8s.io/kube-openapi/pkg/spec3
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/validation/spec
-# k8s.io/test-infra v0.0.0-20221109051814-e69c5f8e8435
+# k8s.io/test-infra v0.0.0-20221121175430-dfec9ce18ddd
 ## explicit; go 1.18
 k8s.io/test-infra/ghproxy/ghcache
 k8s.io/test-infra/ghproxy/ghmetrics


### PR DESCRIPTION
As a requirement for updating it in ci-tools, updating to the latest revision of kubernetes/test-infra.