### PR TITLE
Main branch default version should be 4.13

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -498,7 +498,7 @@ func versionForRefs(refs *prowapiv1.Refs) string {
 		return ""
 	}
 	if refs.BaseRef == "master" || refs.BaseRef == "main" {
-		return "4.12.0-0.latest"
+		return "4.13.0-0.latest"
 	}
 	if m := reBranchVersion.FindStringSubmatch(refs.BaseRef); m != nil {
 		return fmt.Sprintf("%s.0-0.latest", m[2])


### PR DESCRIPTION
When building image with main branch such as https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/201, cluster-bot always build it with unexpected 4.12 build. This want to fix this issue. @bradmwilliams please help to take a look. Thanks!