### PR TITLE
Add space to job succeeded message

### DIFF
--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -250,7 +250,7 @@ func NotifyJob(client *slack.Client, job *manager.Job) {
 			}
 			return
 		case prowapiv1.SuccessState:
-			message := fmt.Sprintf("job <%s|%s> succeeded", job.URL, job.OriginalMessage)
+			message := fmt.Sprintf("job <%s | %s> succeeded", job.URL, job.OriginalMessage)
 			_, _, err := client.PostMessage(job.RequestedChannel, slack.MsgOptionText(message, false))
 			if err != nil {
 				klog.Warningf("Failed to post the message: %s\nto the channel: %s.", message, job.RequestedChannel)


### PR DESCRIPTION
Without space Slack turns it into:

`job <https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1599904280179904512%7Cbuild https://github.com/openshift/installer/pull/6664> succeeded`

Which gives an invalid page when clicked