### PR TITLE
manager: allow users to specify bundle name

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1070,11 +1070,7 @@ func multistageNameFromParams(params map[string]string, platform, jobType string
 	platformParams := multistageParamsForPlatform(platform)
 	variants := sets.NewString()
 	for k := range params {
-		// the `no-spot` param is just a dummy param to disable use of spot instances for basic aws cluster launches
-		if k == "no-spot" {
-			continue
-		}
-		if utils.Contains(SupportedParameters, k) && !platformParams.Has(k) && k != "test" { // we only need parameters that are not configured via multistage env vars
+		if utils.Contains(SupportedParameters, k) && !platformParams.Has(k) && k != "test" && k != "bundle" && k != "no-spot" { // we only need parameters that are not configured via multistage env vars
 			variants.Insert(k)
 		}
 	}


### PR DESCRIPTION
This PR adds the ability for a user to specify what bundle they want to use for an operator launch by adding "bundle=bundleName" to their job parameters.