### PR TITLE
Bumping very verbose message to V(4)

### DIFF
--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -680,7 +680,7 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 					return "", fmt.Errorf("unable to parse ci-operator config definition from resolver: %v", err)
 				}
 				targetConfig := &cfg
-				if klog.V(2) {
+				if klog.V(4) {
 					data, _ := json.MarshalIndent(targetConfig, "", "  ")
 					klog.Infof("Found target job config:\n%s", string(data))
 				}


### PR DESCRIPTION
This particular message can be incredibly chatty when certain repositories are passed into the cluster-bot.  Specifically, PR's from the `openshift/installer` repo returns a `[]byte` that's over 7 million bytes long.  Instead of removing the message all together, I elected to bump it up to a higher log level (`-v 4`). 