### PR TITLE
slack: make hypershift-hosted default for supported versions

### DIFF
--- a/cmd/ci-chat-bot/main.go
+++ b/cmd/ci-chat-bot/main.go
@@ -173,8 +173,6 @@ func run() error {
 	}
 	// Config and Client to access hypershift configmaps
 	var hiveConfigMapClient corev1.ConfigMapInterface
-	// TODO: give the hypershiftSupportedVersions variable to the slack bot for defaulting based on supported versions
-	hypershiftSupportedVersions := manager.HypershiftSupportedVersions{}
 	if config, ok := kubeConfigs["hive"]; ok {
 		hiveClient, err := corev1.NewForConfig(&config)
 		if err != nil {
@@ -216,7 +214,7 @@ func run() error {
 		klog.Warningf("Failed to load lease client. Will not distribute jobs across secondary accounts. Error: %v", err)
 	}
 
-	jobManager := manager.NewJobManager(configAgent, resolver, prowClient, imageClient, buildClusterClientConfigs, ghClient, opt.ForcePROwner, &workflows, opt.leaseClient, hiveConfigMapClient, &hypershiftSupportedVersions)
+	jobManager := manager.NewJobManager(configAgent, resolver, prowClient, imageClient, buildClusterClientConfigs, ghClient, opt.ForcePROwner, &workflows, opt.leaseClient, hiveConfigMapClient)
 	if err := jobManager.Start(); err != nil {
 		return fmt.Errorf("unable to load initial configuration: %w", err)
 	}

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -79,8 +79,6 @@ type jobManager struct {
 		running map[string]struct{}
 	}
 
-	hypershiftSupportedVersions *HypershiftSupportedVersions
-
 	notifierFn     JobCallbackFunc
 	workflowConfig *WorkflowConfig
 
@@ -193,9 +191,9 @@ type Job struct {
 	OperatorBundleName string
 }
 
-type HypershiftSupportedVersions struct {
-	mu       sync.RWMutex
-	versions []string
+type HypershiftSupportedVersionsType struct {
+	Mu       sync.RWMutex
+	Versions sets.String
 }
 
 type ListFilters struct {

--- a/pkg/slack/actions.go
+++ b/pkg/slack/actions.go
@@ -2,6 +2,8 @@ package slack
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/openshift/ci-chat-bot/pkg/manager"
 	"github.com/openshift/ci-chat-bot/pkg/slack/parser"
 	"github.com/openshift/ci-chat-bot/pkg/utils"
@@ -9,7 +11,6 @@ import (
 	"github.com/slack-go/slack/slackevents"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/pkg/version"
-	"strings"
 )
 
 func LaunchCluster(client *slack.Client, jobManager manager.JobManager, event *slackevents.MessageEvent, properties *parser.Properties) string {
@@ -23,7 +24,7 @@ func LaunchCluster(client *slack.Client, jobManager manager.JobManager, event *s
 		inputs = [][]string{from}
 	}
 
-	platform, architecture, params, err := ParseOptions(properties.StringParam("options", ""))
+	platform, architecture, params, err := ParseOptions(properties.StringParam("options", ""), inputs, manager.JobTypeInstall)
 	if err != nil {
 		return err.Error()
 	}
@@ -120,7 +121,7 @@ func TestUpgrade(client *slack.Client, jobManager manager.JobManager, event *sla
 	if len(to) == 0 {
 		to = from
 	}
-	platform, architecture, params, err := ParseOptions(properties.StringParam("options", ""))
+	platform, architecture, params, err := ParseOptions(properties.StringParam("options", ""), [][]string{from, to}, manager.JobTypeUpgrade)
 	if err != nil {
 		return err.Error()
 	}
@@ -167,7 +168,7 @@ func Test(client *slack.Client, jobManager manager.JobManager, event *slackevent
 		return fmt.Sprintf("warning: You are using a custom test name, may not be supported for all platforms: %s", strings.Join(CodeSlice(manager.SupportedTests), ", "))
 	}
 
-	platform, architecture, params, err := ParseOptions(properties.StringParam("options", ""))
+	platform, architecture, params, err := ParseOptions(properties.StringParam("options", ""), [][]string{from}, manager.JobTypeTest)
 	if err != nil {
 		return err.Error()
 	}
@@ -204,7 +205,7 @@ func Build(client *slack.Client, jobManager manager.JobManager, event *slackeven
 		return "you must specify at least one pull request to build a release image"
 	}
 
-	platform, architecture, params, err := ParseOptions(properties.StringParam("options", ""))
+	platform, architecture, params, err := ParseOptions(properties.StringParam("options", ""), [][]string{from}, manager.JobTypeBuild)
 	if err != nil {
 		return err.Error()
 	}


### PR DESCRIPTION
This PR makes the `hypershift-hosted` platform the default for all versions that `hypershift` on the hive cluster supports. It also adds a global variable to define the default openshift release version used by `ci-chat-bot`, makes the `HypershiftSupportedVersions` variable global to make it simpler to access across packages, adds a launch message for cluster launched using `hypershift-hosted`, and removes the estimated launch time from the cluster creation message as that is generally inaccurate now.