### PR TITLE
add interactive `list`

### DIFF
--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -132,7 +132,7 @@ type JobManager interface {
 	TerminateJobForUser(user string) (string, error)
 	GetLaunchJob(user string) (*Job, error)
 	LookupInputs(inputs []string, architecture string) (string, error)
-	ListJobs(users ...string) string
+	ListJobs(users []string, filters ListFilters) string
 	GetWorkflowConfig() *WorkflowConfig
 	ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion, architecture string) (string, string, string, error)
 	ResolveAsPullRequest(spec string) (*prowapiv1.Refs, error)
@@ -196,4 +196,10 @@ type Job struct {
 type HypershiftSupportedVersions struct {
 	mu       sync.RWMutex
 	versions []string
+}
+
+type ListFilters struct {
+	Platform  string
+	Version   string
+	Requestor string
 }

--- a/pkg/slack/actions.go
+++ b/pkg/slack/actions.go
@@ -74,7 +74,7 @@ func Lookup(client *slack.Client, jobManager manager.JobManager, event *slackeve
 }
 
 func List(client *slack.Client, jobManager manager.JobManager, event *slackevents.MessageEvent, properties *parser.Properties) string {
-	return jobManager.ListJobs(event.User)
+	return jobManager.ListJobs([]string{event.User}, manager.ListFilters{})
 }
 
 func Done(client *slack.Client, jobManager manager.JobManager, event *slackevents.MessageEvent, properties *parser.Properties) string {

--- a/pkg/slack/interactions/router/router.go
+++ b/pkg/slack/interactions/router/router.go
@@ -5,6 +5,7 @@ import (
 	"github.com/openshift/ci-chat-bot/pkg/slack/interactions"
 	"github.com/openshift/ci-chat-bot/pkg/slack/modals"
 	"github.com/openshift/ci-chat-bot/pkg/slack/modals/launch"
+	"github.com/openshift/ci-chat-bot/pkg/slack/modals/list"
 	"github.com/openshift/ci-chat-bot/pkg/slack/modals/stepsFromApp"
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
@@ -24,6 +25,7 @@ func ForModals(client *slack.Client, jobmanager manager.JobManager, httpclient *
 		launch.RegisterFirstStep(client, jobmanager, httpclient),
 		launch.RegisterSecondStep(client, jobmanager, httpclient),
 		launch.RegisterThirdStep(client, jobmanager, httpclient),
+		list.Register(client, jobmanager),
 	}
 
 	for _, entry := range toRegister {

--- a/pkg/slack/modals/launch/views.go
+++ b/pkg/slack/modals/launch/views.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"fmt"
 	"github.com/openshift/ci-chat-bot/pkg/manager"
+	"github.com/openshift/ci-chat-bot/pkg/slack/modals"
 	slackClient "github.com/slack-go/slack"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
@@ -30,8 +31,8 @@ const (
 
 // FirstStepView is the modal view for submitting a new enhancement card to Jira
 func FirstStepView() slackClient.ModalViewRequest {
-	platformOptions := buildOptions(manager.SupportedPlatforms, nil)
-	architectureOptions := buildOptions(manager.SupportedArchitectures, nil)
+	platformOptions := modals.BuildOptions(manager.SupportedPlatforms, nil)
+	architectureOptions := modals.BuildOptions(manager.SupportedArchitectures, nil)
 	return slackClient.ModalViewRequest{
 		Type:            slackClient.VTModal,
 		PrivateMetadata: string(Identifier),
@@ -121,8 +122,8 @@ func SecondStepView(callback *slackClient.InteractionCallback, jobmanager manage
 	}
 	sort.Strings(streams)
 	sort.Strings(majorMinorReleases)
-	streamsOptions := buildOptions(streams, nil)
-	majorMinorOptions := buildOptions(majorMinorReleases, nil)
+	streamsOptions := modals.BuildOptions(streams, nil)
+	majorMinorOptions := modals.BuildOptions(majorMinorReleases, nil)
 	return slackClient.ModalViewRequest{
 		Type:            slackClient.VTModal,
 		PrivateMetadata: string(Identifier2ndStep),
@@ -302,7 +303,7 @@ func ThirdStepView(callback *slackClient.InteractionCallback, jobmanager manager
 
 		}
 	}
-	options := buildOptions(manager.SupportedParameters, blacklist)
+	options := modals.BuildOptions(manager.SupportedParameters, blacklist)
 	context := fmt.Sprintf("Architecture: %s;Platform: %s;Version: %s;PRs: %s", architecture, platform, version, prs)
 	return slackClient.ModalViewRequest{
 		Type:            slackClient.VTModal,

--- a/pkg/slack/modals/list/list.go
+++ b/pkg/slack/modals/list/list.go
@@ -1,0 +1,61 @@
+package list
+
+import (
+	"encoding/json"
+	"github.com/openshift/ci-chat-bot/pkg/manager"
+	"github.com/openshift/ci-chat-bot/pkg/slack/interactions"
+	"github.com/openshift/ci-chat-bot/pkg/slack/modals"
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+)
+
+const (
+	Identifier       = "list"
+	filterByVersion  = "filter_by_version"
+	filterByPlatform = "filter_by_platform"
+	filterByUser     = "filter_by_user"
+)
+
+func Register(client *slack.Client, jobmanager manager.JobManager) *modals.FlowWithViewAndFollowUps {
+	return modals.ForView(Identifier, View()).WithFollowUps(map[slack.InteractionType]interactions.Handler{
+		slack.InteractionTypeViewSubmission: processNextForFirstStep(client, jobmanager),
+	})
+}
+
+func processNextForFirstStep(updater *slack.Client, jobmanager manager.JobManager) interactions.Handler {
+	return interactions.HandlerFunc("list", func(callback *slack.InteractionCallback, logger *logrus.Entry) (output []byte, err error) {
+		go func() {
+			inputs := modals.CallBackInputAll(callback)
+			var filters manager.ListFilters
+			for key, input := range inputs {
+				switch key {
+				case filterByPlatform:
+					filters.Platform = input
+				case filterByVersion:
+					filters.Version = input
+				case filterByUser:
+					filters.Requestor = input
+				}
+			}
+			runningJobs := jobmanager.ListJobs([]string{callback.User.ID}, filters)
+			overwriteView := func(view slack.ModalViewRequest) {
+				// don't pass a hash, so we overwrite the View always
+				response, err := updater.UpdateView(view, "", "", callback.View.ID)
+				if err != nil {
+					logger.WithError(err).Warn("Failed to update a modal View.")
+				}
+				logger.WithField("response", response).Trace("Got a modal response.")
+			}
+			overwriteView(SubmissionView(runningJobs))
+		}()
+		response, err := json.Marshal(&slack.ViewSubmissionResponse{
+			ResponseAction: slack.RAUpdate,
+			View:           PrepareNextStepView(),
+		})
+		if err != nil {
+			logger.WithError(err).Error("Failed to marshal FirstStepView update submission response.")
+			return nil, err
+		}
+		return response, nil
+	})
+}

--- a/pkg/slack/modals/list/view.go
+++ b/pkg/slack/modals/list/view.go
@@ -1,0 +1,95 @@
+package list
+
+import (
+	"github.com/openshift/ci-chat-bot/pkg/manager"
+	"github.com/openshift/ci-chat-bot/pkg/slack/modals"
+	slackClient "github.com/slack-go/slack"
+)
+
+func View() slackClient.ModalViewRequest {
+	platformOptions := modals.BuildOptions(manager.SupportedPlatforms, nil)
+	return slackClient.ModalViewRequest{
+		Type:            slackClient.VTModal,
+		PrivateMetadata: string(Identifier),
+		Title:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "List Running Clusters"},
+		Close:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Cancel"},
+		Submit:          &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Submit"},
+		Blocks: slackClient.Blocks{BlockSet: []slackClient.Block{
+			&slackClient.HeaderBlock{
+				Type: slackClient.MBTHeader,
+				Text: &slackClient.TextBlockObject{
+					Type:     "plain_text",
+					Text:     "See who is hogging all the clusters",
+					Emoji:    false,
+					Verbatim: false,
+				},
+			},
+			&slackClient.InputBlock{
+				Type:     slackClient.MBTInput,
+				BlockID:  filterByPlatform,
+				Optional: true,
+				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Filter By platform:"},
+				Element: &slackClient.SelectBlockElement{
+					Type:        slackClient.OptTypeStatic,
+					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select a platform"},
+					Options:     platformOptions,
+				},
+			},
+			&slackClient.InputBlock{
+				Type:     slackClient.MBTInput,
+				BlockID:  filterByVersion,
+				Optional: true,
+				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Filter by version"},
+				Element: &slackClient.PlainTextInputBlockElement{
+					Type:        slackClient.METPlainTextInput,
+					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Enter a version..."},
+				},
+			},
+			&slackClient.SectionBlock{
+				Type:    slackClient.MBTSection,
+				Text:    &slackClient.TextBlockObject{Type: slackClient.MarkdownType, Text: "*Filter by User*"},
+				BlockID: filterByUser,
+				Accessory: &slackClient.Accessory{
+					SelectElement: &slackClient.SelectBlockElement{
+						Type:        "users_select",
+						Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select a User"},
+						ActionID:    "users_select-action",
+					},
+				},
+			},
+		}},
+	}
+}
+
+func SubmissionView(msg string) slackClient.ModalViewRequest {
+	return slackClient.ModalViewRequest{
+		Type:  slackClient.VTModal,
+		Title: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "List Running Clusters"},
+		Close: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Close"},
+		Blocks: slackClient.Blocks{BlockSet: []slackClient.Block{
+			&slackClient.SectionBlock{
+				Type: slackClient.MBTSection,
+				Text: &slackClient.TextBlockObject{
+					Type: slackClient.MarkdownType,
+					Text: msg,
+				},
+			},
+		}},
+	}
+}
+
+func PrepareNextStepView() *slackClient.ModalViewRequest {
+	return &slackClient.ModalViewRequest{
+		Type:  slackClient.VTModal,
+		Title: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "List Running Clusters"},
+		Blocks: slackClient.Blocks{BlockSet: []slackClient.Block{
+			&slackClient.SectionBlock{
+				Type: slackClient.MBTSection,
+				Text: &slackClient.TextBlockObject{
+					Type: slackClient.MarkdownType,
+					Text: "Processing the next step, do not close this window...",
+				},
+			},
+		}},
+	}
+}


### PR DESCRIPTION
This PR adds an interactive `list` command. 
The functionality remains the same, only adding options to filter the output. 

A few reusable functions are moved from `launch.go` to `handlers.go`. 