### PR TITLE
interactive `list`: change view type

### DIFF
--- a/pkg/slack/modals/list/view.go
+++ b/pkg/slack/modals/list/view.go
@@ -67,12 +67,17 @@ func SubmissionView(msg string) slackClient.ModalViewRequest {
 		Title: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "List Running Clusters"},
 		Close: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Close"},
 		Blocks: slackClient.Blocks{BlockSet: []slackClient.Block{
-			&slackClient.SectionBlock{
-				Type: slackClient.MBTSection,
-				Text: &slackClient.TextBlockObject{
-					Type: slackClient.MarkdownType,
-					Text: msg,
-				},
+			&slackClient.ContextBlock{
+				Type:    slackClient.MBTContext,
+				BlockID: "list",
+				ContextElements: slackClient.ContextElements{Elements: []slackClient.MixedElement{
+					&slackClient.TextBlockObject{
+						Type:     slackClient.MarkdownType,
+						Text:     msg,
+						Emoji:    false,
+						Verbatim: false,
+					},
+				}},
 			},
 		}},
 	}


### PR DESCRIPTION
The current view type (`section`) has a limit for the number of characters that it can display. If the output is too long, it will fail to display it. 
Changing to type `context`. 