### PR TITLE
update interactive `launch`

### DIFF
--- a/pkg/slack/interactions/router/router.go
+++ b/pkg/slack/interactions/router/router.go
@@ -25,8 +25,11 @@ func ForModals(client *slack.Client, jobmanager manager.JobManager, httpclient *
 
 	toRegister := []*modals.FlowWithViewAndFollowUps{
 		launch.RegisterFirstStep(client, jobmanager, httpclient),
-		launch.RegisterSecondStep(client, jobmanager, httpclient),
+		launch.RegisterLaunchModeStep(client, jobmanager, httpclient),
 		launch.RegisterThirdStep(client, jobmanager, httpclient),
+		launch.RegisterSelectVersion(client, jobmanager, httpclient),
+		launch.RegisterFilterVersion(client, jobmanager, httpclient),
+		launch.RegisterPRInput(client, jobmanager, httpclient),
 		list.Register(client, jobmanager),
 		done.Register(client, jobmanager),
 		refresh.Register(client, jobmanager),

--- a/pkg/slack/modals/launch/views.go
+++ b/pkg/slack/modals/launch/views.go
@@ -12,30 +12,13 @@ import (
 	"strings"
 )
 
-const (
-	stableReleasesPrefix        = "4-stable"
-	launchFromPR                = "prs"
-	launchFromMajorMinor        = "major_minor"
-	launchFromStream            = "stream"
-	launchFromLatestBuild       = "latest_build"
-	launchFromReleaseController = "release_controller_version"
-	launchFromCustom            = "custom"
-	launchPlatform              = "platform"
-	launchArchitecture          = "architecture"
-	launchParameters            = "parameters"
-	launchVersion               = "version"
-	launchStepContext           = "context"
-	defaultPlatform             = "aws"
-	defaultArchitecture         = "amd64"
-)
-
 // FirstStepView is the modal view for submitting a new enhancement card to Jira
 func FirstStepView() slackClient.ModalViewRequest {
 	platformOptions := modals.BuildOptions(manager.SupportedPlatforms, nil)
 	architectureOptions := modals.BuildOptions(manager.SupportedArchitectures, nil)
 	return slackClient.ModalViewRequest{
 		Type:            slackClient.VTModal,
-		PrivateMetadata: string(Identifier),
+		PrivateMetadata: string(IdentifierInitialView),
 		Title:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Launch a Cluster"},
 		Close:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Cancel"},
 		Submit:          &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Next"},
@@ -70,200 +53,6 @@ func FirstStepView() slackClient.ModalViewRequest {
 					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "amd64"},
 					Options:     architectureOptions,
 				},
-			},
-		}},
-	}
-}
-
-func SecondStepView(callback *slackClient.InteractionCallback, jobmanager manager.JobManager, httpclient *http.Client, data callbackData) slackClient.ModalViewRequest {
-	if callback == nil {
-		return slackClient.ModalViewRequest{}
-	}
-	platform, ok := data.input[launchPlatform]
-	if !ok {
-		platform = defaultPlatform
-	}
-	architecture, ok := data.input[launchArchitecture]
-	if !ok {
-		architecture = defaultArchitecture
-	}
-	metadata := fmt.Sprintf("Architecture: %s; Platform: %s", architecture, platform)
-	_, nightly, _, err := jobmanager.ResolveImageOrVersion("nightly", "", architecture)
-	if err != nil {
-		nightly = fmt.Sprintf("unable to find a release matching `nightly` for %s", architecture)
-	}
-	_, ci, _, err := jobmanager.ResolveImageOrVersion("ci", "", architecture)
-	if err != nil {
-		ci = fmt.Sprintf("unable to find a release matching \"ci\" for %s", architecture)
-	}
-	releases, err := fetchReleases(httpclient, architecture)
-	if err != nil {
-		// TODO - return an error view, with a try again
-		klog.Warningf("failed to fetch the data from release controller: %s", err)
-	}
-	var streams []string
-	majorMinor := make(map[string]bool, 0)
-	for stream, tags := range releases {
-		if strings.HasPrefix(stream, stableReleasesPrefix) {
-			for _, tag := range tags {
-				splitTag := strings.Split(tag, ".")
-				if len(splitTag) >= 2 {
-					majorMinor[fmt.Sprintf("%s.%s", splitTag[0], splitTag[1])] = true
-				}
-			}
-
-		}
-		streams = append(streams, stream)
-	}
-
-	var majorMinorReleases []string
-	for key := range majorMinor {
-		majorMinorReleases = append(majorMinorReleases, key)
-	}
-	sort.Strings(streams)
-	sort.Strings(majorMinorReleases)
-	streamsOptions := modals.BuildOptions(streams, nil)
-	majorMinorOptions := modals.BuildOptions(majorMinorReleases, nil)
-	return slackClient.ModalViewRequest{
-		Type:            slackClient.VTModal,
-		PrivateMetadata: string(Identifier2ndStep),
-		Title:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Launch a Cluster"},
-		Close:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Cancel"},
-		Submit:          &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Next"},
-		Blocks: slackClient.Blocks{BlockSet: []slackClient.Block{
-			&slackClient.HeaderBlock{
-				Type: slackClient.MBTHeader,
-				Text: &slackClient.TextBlockObject{
-					Type:     slackClient.PlainTextType,
-					Text:     "Select a Version or enter a PR",
-					Emoji:    false,
-					Verbatim: false,
-				},
-			},
-			&slackClient.SectionBlock{
-				Type: slackClient.MBTSection,
-				Text: &slackClient.TextBlockObject{
-					Type: slackClient.MarkdownType,
-					Text: "Select *only one of the following:* a Version, Stream name, Major/Minor or a Custom Build, and one or multiple PRs. All inputs are optional",
-				},
-			},
-			&slackClient.DividerBlock{
-				Type:    slackClient.MBTDivider,
-				BlockID: "divider",
-			},
-			&slackClient.HeaderBlock{
-				Type: slackClient.MBTHeader,
-				Text: &slackClient.TextBlockObject{
-					Type:     slackClient.PlainTextType,
-					Text:     "Versions",
-					Emoji:    false,
-					Verbatim: false,
-				},
-			},
-			&slackClient.InputBlock{
-				Type:     slackClient.MBTInput,
-				BlockID:  launchFromReleaseController,
-				Optional: true,
-				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "A version directly from Release-Controller:"},
-				Element: &slackClient.PlainTextInputBlockElement{
-					Type:        slackClient.METPlainTextInput,
-					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Enter a version...."},
-				},
-			},
-			&slackClient.SectionBlock{
-				Type: slackClient.MBTSection,
-				Text: &slackClient.TextBlockObject{
-					Type: slackClient.MarkdownType,
-					Text: fmt.Sprintf("<https://%s.ocp.releases.ci.openshift.org|Link to Release Controller>", architecture),
-				},
-			},
-			&slackClient.InputBlock{
-				Type:     slackClient.MBTInput,
-				BlockID:  launchFromLatestBuild,
-				Optional: true,
-				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "The latest build (nightly) or CI build:"},
-				Element: &slackClient.SelectBlockElement{
-					Type:        slackClient.OptTypeStatic,
-					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select an entry..."},
-					Options: []*slackClient.OptionBlockObject{
-						{Value: "nightly", Text: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: nightly}},
-						{Value: "ci", Text: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: ci}},
-					},
-				},
-			},
-			&slackClient.InputBlock{
-				Type:     slackClient.MBTInput,
-				BlockID:  launchFromStream,
-				Optional: true,
-				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "A Stream Name:"},
-				Element: &slackClient.SelectBlockElement{
-					Type:        slackClient.OptTypeStatic,
-					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select an entry..."},
-					Options:     streamsOptions,
-				},
-			},
-			&slackClient.InputBlock{
-				Type:     slackClient.MBTInput,
-				BlockID:  launchFromMajorMinor,
-				Optional: true,
-				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Major/Minor"},
-				Element: &slackClient.SelectBlockElement{
-					Type:        slackClient.OptTypeStatic,
-					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select an entry..."},
-					Options:     majorMinorOptions,
-				},
-			},
-			&slackClient.InputBlock{
-				Type:     slackClient.MBTInput,
-				BlockID:  launchFromCustom,
-				Optional: true,
-				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Custom build:"},
-				Element: &slackClient.PlainTextInputBlockElement{
-					Type:        slackClient.METPlainTextInput,
-					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Enter a custom build...."},
-				},
-			},
-			&slackClient.HeaderBlock{
-				Type: slackClient.MBTHeader,
-				Text: &slackClient.TextBlockObject{
-					Type:     slackClient.PlainTextType,
-					Text:     "PR",
-					Emoji:    false,
-					Verbatim: false,
-				},
-			},
-			&slackClient.SectionBlock{
-				Type: slackClient.MBTSection,
-				Text: &slackClient.TextBlockObject{
-					Type: slackClient.MarkdownType,
-					Text: ":pull-request: *Enter one or more PRs, separated by coma*",
-				},
-			},
-			&slackClient.InputBlock{
-				Type:     slackClient.MBTInput,
-				BlockID:  launchFromPR,
-				Optional: true,
-				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Enter one or more PRs:"},
-				Element: &slackClient.PlainTextInputBlockElement{
-					Type:        slackClient.METPlainTextInput,
-					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Enter one or more PRs..."},
-				},
-			},
-			&slackClient.DividerBlock{
-				Type:    slackClient.MBTDivider,
-				BlockID: "3rd_divider",
-			},
-			&slackClient.ContextBlock{
-				Type:    slackClient.MBTContext,
-				BlockID: launchStepContext,
-				ContextElements: slackClient.ContextElements{Elements: []slackClient.MixedElement{
-					&slackClient.TextBlockObject{
-						Type:     slackClient.PlainTextType,
-						Text:     metadata,
-						Emoji:    false,
-						Verbatim: false,
-					},
-				}},
 			},
 		}},
 	}
@@ -304,7 +93,7 @@ func ThirdStepView(callback *slackClient.InteractionCallback, jobmanager manager
 		}
 	}
 	options := modals.BuildOptions(manager.SupportedParameters, blacklist)
-	context := fmt.Sprintf("Architecture: %s;Platform: %s;Version: %s;PRs: %s", architecture, platform, version, prs)
+	context := fmt.Sprintf("Architecture: %s;Platform: %s;Version: %s;PR: %s", architecture, platform, version, prs)
 	return slackClient.ModalViewRequest{
 		Type:            slackClient.VTModal,
 		PrivateMetadata: string(Identifier3rdStep),
@@ -371,6 +160,350 @@ func SubmissionView(msg string) slackClient.ModalViewRequest {
 					Type: slackClient.MarkdownType,
 					Text: msg,
 				},
+			},
+		}},
+	}
+}
+
+func SelectModeView(callback *slackClient.InteractionCallback, jobmanager manager.JobManager, data callbackData) slackClient.ModalViewRequest {
+	if callback == nil {
+		return slackClient.ModalViewRequest{}
+	}
+	platform, ok := data.input[launchPlatform]
+	if !ok {
+		platform = defaultPlatform
+	}
+	architecture, ok := data.input[launchArchitecture]
+	if !ok {
+		architecture = defaultArchitecture
+	}
+	metadata := fmt.Sprintf("Architecture: %s; Platform: %s", architecture, platform)
+	options := modals.BuildOptions([]string{launchModePRKey, launchModeVersionKey}, nil)
+	return slackClient.ModalViewRequest{
+		Type:            slackClient.VTModal,
+		PrivateMetadata: string(IdentifierRegisterLaunchMode),
+		Title:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Launch a Workflow"},
+		Close:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Cancel"},
+		Submit:          &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Next"},
+		Blocks: slackClient.Blocks{BlockSet: []slackClient.Block{
+			&slackClient.HeaderBlock{
+				Type: slackClient.MBTHeader,
+				Text: &slackClient.TextBlockObject{
+					Type:     slackClient.PlainTextType,
+					Text:     "Select the launch mode",
+					Emoji:    false,
+					Verbatim: false,
+				},
+			},
+			&slackClient.InputBlock{
+				Type:    slackClient.MBTInput,
+				BlockID: launchMode,
+				Label:   &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Launch the Cluster using:"},
+				Element: &slackClient.CheckboxGroupsBlockElement{
+					Type:    slackClient.METCheckboxGroups,
+					Options: options,
+				},
+			},
+			&slackClient.DividerBlock{
+				Type:    slackClient.MBTDivider,
+				BlockID: "divider",
+			},
+			&slackClient.ContextBlock{
+				Type:    slackClient.MBTContext,
+				BlockID: launchStepContext,
+				ContextElements: slackClient.ContextElements{Elements: []slackClient.MixedElement{
+					&slackClient.TextBlockObject{
+						Type:     slackClient.PlainTextType,
+						Text:     metadata,
+						Emoji:    false,
+						Verbatim: false,
+					},
+				}},
+			},
+		}},
+	}
+}
+
+func FilterVersionView(callback *slackClient.InteractionCallback, jobmanager manager.JobManager, data callbackData, httpclient *http.Client, mode sets.String) slackClient.ModalViewRequest {
+	if callback == nil {
+		return slackClient.ModalViewRequest{}
+	}
+	platform := data.context[launchPlatform]
+	architecture := data.context[launchArchitecture]
+	//launchMode := data.multipleSelection[launchMode]
+	_, nightly, _, err := jobmanager.ResolveImageOrVersion("nightly", "", architecture)
+	if err != nil {
+		nightly = fmt.Sprintf("unable to find a release matching `nightly` for %s", architecture)
+	}
+	_, ci, _, err := jobmanager.ResolveImageOrVersion("ci", "", architecture)
+	if err != nil {
+		ci = fmt.Sprintf("unable to find a release matching \"ci\" for %s", architecture)
+	}
+	releases, err := fetchReleases(httpclient, architecture)
+	if err != nil {
+		// TODO - return an error view, with a try again
+		klog.Warningf("failed to fetch the data from release controller: %s", err)
+	}
+	var streams []string
+	majorMinor := make(map[string]bool, 0)
+	for stream, tags := range releases {
+		if strings.HasPrefix(stream, stableReleasesPrefix) {
+			for _, tag := range tags {
+				splitTag := strings.Split(tag, ".")
+				if len(splitTag) >= 2 {
+					majorMinor[fmt.Sprintf("%s.%s", splitTag[0], splitTag[1])] = true
+				}
+			}
+
+		}
+		streams = append(streams, stream)
+	}
+
+	var majorMinorReleases []string
+	for key := range majorMinor {
+		majorMinorReleases = append(majorMinorReleases, key)
+	}
+	sort.Strings(streams)
+	sort.Strings(majorMinorReleases)
+	streamsOptions := modals.BuildOptions(streams, nil)
+	majorMinorOptions := modals.BuildOptions(majorMinorReleases, nil)
+	metadata := fmt.Sprintf("Architecture: %s;Platform: %s;%s: %s", architecture, platform, launchModeContext, strings.Join(mode.List(), ","))
+	return slackClient.ModalViewRequest{
+		Type:            slackClient.VTModal,
+		PrivateMetadata: string(IdentifierFilterVersionView),
+		Title:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Launch a Workflow"},
+		Close:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Cancel"},
+		Submit:          &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Next"},
+		Blocks: slackClient.Blocks{BlockSet: []slackClient.Block{
+			&slackClient.HeaderBlock{
+				Type: slackClient.MBTHeader,
+				Text: &slackClient.TextBlockObject{
+					Type:     slackClient.PlainTextType,
+					Text:     "Version Specifications",
+					Emoji:    false,
+					Verbatim: false,
+				},
+			},
+			&slackClient.SectionBlock{
+				Type: slackClient.MBTSection,
+				Text: &slackClient.TextBlockObject{
+					Type: slackClient.MarkdownType,
+					Text: "*To get a list of version to select from, specify the _stream_ and/or _major.minor_*\nIf the *_stable_* stream is selected, please specify the *_major.minor_* as well.\nFor any other *_streams_*, you may omit the major.minor",
+				},
+			},
+			&slackClient.DividerBlock{
+				Type:    slackClient.MBTDivider,
+				BlockID: "divider_section",
+			},
+			&slackClient.InputBlock{
+				Type:     slackClient.MBTInput,
+				BlockID:  launchFromStream,
+				Optional: true,
+				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Specify the Stream:"},
+				Element: &slackClient.SelectBlockElement{
+					Type:        slackClient.OptTypeStatic,
+					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select an entry..."},
+					Options:     streamsOptions,
+				},
+			},
+			&slackClient.InputBlock{
+				Type:     slackClient.MBTInput,
+				BlockID:  launchFromMajorMinor,
+				Optional: true,
+				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Specify the Major.Minor:"},
+				Element: &slackClient.SelectBlockElement{
+					Type:        slackClient.OptTypeStatic,
+					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select an entry..."},
+					Options:     majorMinorOptions,
+				},
+			},
+			&slackClient.SectionBlock{
+				Type: slackClient.MBTSection,
+				Text: &slackClient.TextBlockObject{
+					Type: slackClient.MarkdownType,
+					Text: "\n*Alternatively:*\n*Launch using the latest Nightly or CI build*",
+				},
+			},
+			&slackClient.DividerBlock{
+				Type:    slackClient.MBTDivider,
+				BlockID: "divider_2nd_section",
+			},
+			&slackClient.InputBlock{
+				Type:     slackClient.MBTInput,
+				BlockID:  launchFromLatestBuild,
+				Optional: true,
+				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "The latest build (nightly) or CI build:"},
+				Element: &slackClient.SelectBlockElement{
+					Type:        slackClient.OptTypeStatic,
+					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select an entry..."},
+					Options: []*slackClient.OptionBlockObject{
+						{Value: "nightly", Text: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: nightly}},
+						{Value: "ci", Text: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: ci}},
+					},
+				},
+			},
+			&slackClient.DividerBlock{
+				Type:    slackClient.MBTDivider,
+				BlockID: "divider",
+			},
+			&slackClient.ContextBlock{
+				Type:    slackClient.MBTContext,
+				BlockID: launchStepContext,
+				ContextElements: slackClient.ContextElements{Elements: []slackClient.MixedElement{
+					&slackClient.TextBlockObject{
+						Type:     slackClient.PlainTextType,
+						Text:     metadata,
+						Emoji:    false,
+						Verbatim: false,
+					},
+				}},
+			},
+		}},
+	}
+}
+
+func PRInputView(callback *slackClient.InteractionCallback, data callbackData) slackClient.ModalViewRequest {
+	if callback == nil {
+		return slackClient.ModalViewRequest{}
+	}
+	platform := data.context[launchPlatform]
+	architecture := data.context[launchArchitecture]
+	mode := data.context[launchMode]
+	launchModeSplit := strings.Split(mode, ",")
+	launchWithVersion := false
+	for _, key := range launchModeSplit {
+		if strings.TrimSpace(key) == launchVersion {
+			launchWithVersion = true
+		}
+	}
+	metadata := fmt.Sprintf("Architecture: %s; Platform: %s;%s: %s", architecture, platform, launchModeContext, mode)
+	if launchWithVersion {
+		version := data.input[launchVersion]
+		if version == "" {
+			version = data.input[launchFromLatestBuild]
+		}
+		metadata = fmt.Sprintf("%s;Version: %s", metadata, version)
+	}
+	return slackClient.ModalViewRequest{
+		Type:            slackClient.VTModal,
+		PrivateMetadata: string(IdentifierPRInputView),
+		Title:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Launch a Workflow"},
+		Close:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Cancel"},
+		Submit:          &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Next"},
+		Blocks: slackClient.Blocks{BlockSet: []slackClient.Block{
+			&slackClient.HeaderBlock{
+				Type: slackClient.MBTHeader,
+				Text: &slackClient.TextBlockObject{
+					Type:     slackClient.PlainTextType,
+					Text:     "Enter A PR",
+					Emoji:    false,
+					Verbatim: false,
+				},
+			},
+			&slackClient.InputBlock{
+				Type:    slackClient.MBTInput,
+				BlockID: launchFromPR,
+				Label:   &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Enter one or more PRs, separated by coma:"},
+				Element: &slackClient.PlainTextInputBlockElement{
+					Type:        slackClient.METPlainTextInput,
+					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Enter one or more PRs..."},
+				},
+			},
+			&slackClient.DividerBlock{
+				Type:    slackClient.MBTDivider,
+				BlockID: "divider",
+			},
+			&slackClient.ContextBlock{
+				Type:    slackClient.MBTContext,
+				BlockID: launchStepContext,
+				ContextElements: slackClient.ContextElements{Elements: []slackClient.MixedElement{
+					&slackClient.TextBlockObject{
+						Type:     slackClient.PlainTextType,
+						Text:     metadata,
+						Emoji:    false,
+						Verbatim: false,
+					},
+				}},
+			},
+		}},
+	}
+}
+
+func SelectVersionView(callback *slackClient.InteractionCallback, jobmanager manager.JobManager, httpclient *http.Client, data callbackData) slackClient.ModalViewRequest {
+	if callback == nil {
+		return slackClient.ModalViewRequest{}
+	}
+
+	platform := data.context[launchPlatform]
+	architecture := data.context[launchArchitecture]
+	mode := data.context[launchMode]
+	selectedStream := data.input[launchFromStream]
+	selectedMajonMinor := data.input[launchFromMajorMinor]
+	metadata := fmt.Sprintf("Architecture: %s; Platform: %s; %s: %s", architecture, platform, launchModeContext, mode)
+	releases, err := fetchReleases(httpclient, architecture)
+	if err != nil {
+		// TODO - return an error view, with a try again
+		klog.Warningf("failed to fetch the data from release controller: %s", err)
+	}
+	var allTags []string
+	for stream, tags := range releases {
+		if stream == selectedStream {
+			for _, tag := range tags {
+				if strings.HasPrefix(tag, selectedMajonMinor) {
+					allTags = append(allTags, tag)
+				}
+			}
+
+		}
+	}
+	//sort.Strings(allTags)
+	allTagsOptions := modals.BuildOptions(allTags, nil)
+	return slackClient.ModalViewRequest{
+		Type:            slackClient.VTModal,
+		PrivateMetadata: string(IdentifierSelectVersion),
+		Title:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Launch a Cluster"},
+		Close:           &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Cancel"},
+		Submit:          &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Next"},
+		Blocks: slackClient.Blocks{BlockSet: []slackClient.Block{
+			&slackClient.HeaderBlock{
+				Type: slackClient.MBTHeader,
+				Text: &slackClient.TextBlockObject{
+					Type:     slackClient.PlainTextType,
+					Text:     "Select a Version",
+					Emoji:    false,
+					Verbatim: false,
+				},
+			},
+			&slackClient.DividerBlock{
+				Type:    slackClient.MBTDivider,
+				BlockID: "divider",
+			},
+			&slackClient.InputBlock{
+				Type:     slackClient.MBTInput,
+				BlockID:  launchVersion,
+				Optional: true,
+				Label:    &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select a version:"},
+				Element: &slackClient.SelectBlockElement{
+					Type:        slackClient.OptTypeStatic,
+					Placeholder: &slackClient.TextBlockObject{Type: slackClient.PlainTextType, Text: "Select an entry..."},
+					Options:     allTagsOptions,
+				},
+			},
+			&slackClient.DividerBlock{
+				Type:    slackClient.MBTDivider,
+				BlockID: "context_divider",
+			},
+			&slackClient.ContextBlock{
+				Type:    slackClient.MBTContext,
+				BlockID: launchStepContext,
+				ContextElements: slackClient.ContextElements{Elements: []slackClient.MixedElement{
+					&slackClient.TextBlockObject{
+						Type:     slackClient.PlainTextType,
+						Text:     metadata,
+						Emoji:    false,
+						Verbatim: false,
+					},
+				}},
 			},
 		}},
 	}


### PR DESCRIPTION
Add a few in-between steps when selecting the version, to avoid having to redirect users to the `release-controller` page. 