### PR TITLE
manager: default no inputs for nightly

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -799,7 +799,7 @@ func (m *jobManager) LookupInputs(inputs []string, architecture string) (string,
 	if err != nil {
 		return "", err
 	}
-	// len(inputs) much match len(JobInputs), so if lookupInputs defaulted a version, we need to update inputs
+	// len(inputs) must match len(JobInputs), so if lookupInputs defaulted a version, we need to update inputs
 	if defaultedVersion != "" {
 		inputs = []string{defaultedVersion}
 	}


### PR DESCRIPTION
This PR consolidates the empty `inputs` version defaulting to the `lookupInputs` function and configures the default as the latest `nightly`.