### PR TITLE
manager: look up SCOS releases

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -593,6 +593,7 @@ func (m *jobManager) ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp", Imagestream: "release"})
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp", Imagestream: "4-dev-preview"})
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "origin", Imagestream: "release"})
+		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "origin", Imagestream: "scos-release"})
 	case "arm64":
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp-arm64", Imagestream: "release-arm64", ArchSuffix: "-arm64"})
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp-arm64", Imagestream: "4-dev-preview-arm64", ArchSuffix: "-arm64"})


### PR DESCRIPTION
OKD SCOS releases are stored in scos-release imagestream in origin  namespace.

This would enable chat bot to run SCOS images via name (`launch 4.13.0-0.okd-scos-2023-03-29-124824`) instead of a full pullspec