### PR TITLE
Enable the cluster profile to be specified for workflow-launch

### DIFF
--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -439,14 +439,18 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 	if job.Mode == JobTypeWorkflowLaunch || job.Mode == JobTypeWorkflowUpgrade {
 		// use "launch" test name to identify proper cluster profile
 		var profile citools.ClusterProfile
-		for _, test := range sourceConfig.Tests {
-			if test.As == "launch" {
-				profile = test.MultiStageTestConfiguration.ClusterProfile
-			}
-		}
 		environment := citools.TestEnvironment{}
 		for name, value := range job.JobParams {
 			environment[name] = value
+		}
+		for _, test := range sourceConfig.Tests {
+			if test.As == "launch" {
+				if val, exists := environment["CLUSTER_PROFILE"]; exists {
+					profile = citools.ClusterProfile(val)
+				} else {
+					profile = test.MultiStageTestConfiguration.ClusterProfile
+				}
+			}
 		}
 		test := citools.TestStepConfiguration{
 			As: "launch",


### PR DESCRIPTION
For some platforms, particularly vSphere, there are numerous environment variations that require that specific workflows run in their associated lease pools.  The intent of this PR is to introduce a parameter to workflow-launch to allow a specific cluster profile to chosen.

Alternatively, additional launch variants could be created for vSphere but this would add numerous variants which are entirely irrelevant to other platforms.  Additionally, this makes the help more confusing and requires additional maintenance to add a new variant each time we introduce a new  configuration or environment to test.