### PR TITLE
Dockerfile: add rosa to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN make
 
 FROM registry.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/ci-chat-bot/ci-chat-bot /usr/bin/
+RUN curl -s -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/1.2.15/rosa-linux.tar.gz | tar -xvz -C /usr/bin
 ENTRYPOINT ["/usr/bin/ci-chat-bot"]


### PR DESCRIPTION
This PR adds rosa version 1.2.15 to the ci-chat-bot image.