### PR TITLE
main,manager: add metrics for rosa

### DIFF
--- a/cmd/ci-chat-bot/slack.go
+++ b/cmd/ci-chat-bot/slack.go
@@ -27,15 +27,11 @@ import (
 	"k8s.io/test-infra/prow/simplifypath"
 )
 
-var (
-	promMetrics = metrics.NewMetrics("cluster_bot")
-)
-
 func l(fragment string, children ...simplifypath.Node) simplifypath.Node {
 	return simplifypath.L(fragment, children...)
 }
 
-func Start(bot *slack.Bot, jiraclient *jiraClient.Client, jobManager manager.JobManager, httpclient *http.Client, health *pjutil.Health, iOpts prowflagutil.InstrumentationOptions) {
+func Start(bot *slack.Bot, jiraclient *jiraClient.Client, jobManager manager.JobManager, httpclient *http.Client, health *pjutil.Health, iOpts prowflagutil.InstrumentationOptions, clusterBotMetrics *metrics.Metrics) {
 	slackclient := slackClient.New(bot.BotToken)
 	jobManager.SetNotifier(bot.JobResponder(slackclient))
 	jobManager.SetRosaNotifier(bot.RosaResponder(slackclient))
@@ -58,7 +54,7 @@ func Start(bot *slack.Bot, jiraclient *jiraClient.Client, jobManager manager.Job
 			l("events-endpoint"),
 		),
 	))
-	handler := metrics.TraceHandler(simplifier, promMetrics.HTTPRequestDuration, promMetrics.HTTPResponseSize)
+	handler := metrics.TraceHandler(simplifier, clusterBotMetrics.HTTPRequestDuration, clusterBotMetrics.HTTPResponseSize)
 	pprof.Instrument(iOpts)
 	mux := http.NewServeMux()
 	// handle the root to allow for a simple uptime probe

--- a/go.mod
+++ b/go.mod
@@ -142,7 +142,7 @@ require (
 	github.com/openshift/rosa v1.2.16-0.20230327183030-74d07edb1234
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.14.0 // indirect
+	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect


### PR DESCRIPTION
This adds 6 histogram metrics for measuring rosa cluster start time and rosaSync time statistics as well as many error metrics that can be used for alerts and keeping track of potential issues from rosa.

This also reduces the sync time for the `rosaSync` function to 1 minute to help better track launch times for rosa clusters.