### PR TITLE
images,pkg: add new Dockerfile

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.ci.openshift.org/openshift/centos:stream9
+LABEL maintainer="apavel@redhat.com"
+ADD ci-chat-bot /usr/bin/ci-chat-bot
+RUN curl -s -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/1.2.15/rosa-linux.tar.gz | tar -xvz -C /usr/bin
+ENTRYPOINT ["/usr/bin/ci-chat-bot"]

--- a/pkg/slack/modals/launch/steps/filterVersion.go
+++ b/pkg/slack/modals/launch/steps/filterVersion.go
@@ -80,10 +80,7 @@ func checkVariables(vars ...string) bool {
 			count++
 		}
 	}
-	if count > 1 {
-		return false
-	}
-	return true
+	return count <= 1
 }
 
 func validateFilterVersion(submissionData launch.CallbackData) []byte {

--- a/pkg/slack/modals/launch/views.go
+++ b/pkg/slack/modals/launch/views.go
@@ -565,14 +565,6 @@ func SelectMinorMajor(callback *slackClient.InteractionCallback, httpclient *htt
 		klog.Warningf("failed to fetch the data from release controller: %s", err)
 		return ErrorView(err.Error())
 	}
-	var allTags []string
-	for stream, tags := range releases {
-		if stream == selectedStream {
-			for _, tag := range tags {
-				allTags = append(allTags, tag)
-			}
-		}
-	}
 
 	majorMinor := make(map[string]bool, 0)
 	for stream, tags := range releases {


### PR DESCRIPTION
This PR adds a new Dockerfile to allow the `ci-chat-bot` image to be built in a similar manner to other CRT projects.

This PR also fixes some lint warnings that occur when using `golangci-lint` with go > 1.18.

A future PR will remove the old Dockerfile once the openshift/release config is updated.