### PR TITLE
manager: stop spamming failed rosa clusters

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -339,8 +339,14 @@ func (m *jobManager) rosaSync() error {
 				if previous != nil {
 					metrics.RecordError(errorRosaFailure, m.errorMetric)
 				}
-				klog.Infof("Reporting failure for cluster %s", cluster.ID())
-				m.rosaNotifierFn(cluster, "")
+				if m.rosaErrorReported == nil {
+					m.rosaErrorReported = sets.NewString()
+				}
+				if !m.rosaErrorReported.Has(cluster.ID()) {
+					klog.Infof("Reporting failure for cluster %s", cluster.ID())
+					m.rosaNotifierFn(cluster, "")
+					m.rosaErrorReported.Insert(cluster.ID())
+				}
 			}
 		}
 		expiryTime, err := base64.RawStdEncoding.DecodeString(cluster.AWS().Tags()[utils.ExpiryTimeTag])

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -193,8 +193,9 @@ type jobManager struct {
 		lock     sync.RWMutex
 		versions []string
 	}
-	rosaClusterLimit int
-	rosaSubnets      *RosaSubnets
+	rosaClusterLimit  int
+	rosaSubnets       *RosaSubnets
+	rosaErrorReported sets.String
 
 	maxRosaAge       time.Duration
 	defaultRosaAge   time.Duration

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -456,7 +456,7 @@ func NotifyRosa(client *slack.Client, cluster *clustermgmtv1.Cluster, password s
 	channel := cluster.AWS().Tags()[utils.ChannelTag]
 	switch {
 	case cluster.State() == clustermgmtv1.ClusterStateError:
-		message := "your cluster failed to launch"
+		message := fmt.Sprintf("your cluster (name: `%s`, id: `%s`) has encountered an error; please contact the CRT team in #forum-crt", cluster.Name(), cluster.ID())
 		_, _, err := client.PostMessage(channel, slack.MsgOptionText(message, false))
 		if err != nil {
 			klog.Warningf("Failed to post the message: %s\nto the channel: %s.", message, channel)


### PR DESCRIPTION
This PR keeps an in-memory log of cluster IDs that the chat-bot has reported failures for. In some cases, a cluster will go back and forth between states (specifically "Uninstalling" and "Error"), which causes the error message to be spammed to the user. Using a set to track this prevents the error from being sent to a user more than once per instance of cluster-bot.