### PR TITLE
Dockerfile,images/Dockerfile: fix dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
-WORKDIR /go/src/github.com/openshift/ci-chat-bot
-COPY . .
-RUN make
-
-FROM registry.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/openshift/ci-chat-bot/ci-chat-bot /usr/bin/
-RUN curl -s -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/1.2.22/rosa-linux.tar.gz | tar -xvz -C /usr/bin
-ENTRYPOINT ["/usr/bin/ci-chat-bot"]

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/openshift/centos:stream9
 LABEL maintainer="apavel@redhat.com"
 ADD ci-chat-bot /usr/bin/ci-chat-bot
-RUN curl -s -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/1.2.15/rosa-linux.tar.gz | tar -xvz -C /usr/bin
+RUN curl -s -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/1.2.22/rosa-linux.tar.gz | tar -xvz -C /usr/bin
 ENTRYPOINT ["/usr/bin/ci-chat-bot"]


### PR DESCRIPTION
During the move to a newer required version of ROSA, the old, unused Dockerfile was updated, but the currently used one was not. This PR removes the old Dockerfile and updates the currently used one.