### PR TITLE
HOSTEDCP-1078: remove hypershift platform

### DIFF
--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -52,7 +52,7 @@ var SupportedUpgradeTests = []string{"e2e-upgrade", "e2e-upgrade-all", "e2e-upgr
 
 // SupportedPlatforms requires a job within the release periodics that can launch a
 // cluster that has the label job-env: platform-name.
-var SupportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal", "hypershift", "ovirt", "openstack", "hypershift-hosted"}
+var SupportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal", "ovirt", "openstack", "hypershift-hosted"}
 
 // SupportedParameters are the allowed parameter keys that can be passed to jobs
 var SupportedParameters = []string{"ovn", "ovn-hybrid", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv4", "ipv6", "dualstack", "preserve-bootstrap", "test", "rt", "single-node", "cgroupsv2", "techpreview", "upi", "crun", "nfv", "kuryr", "sdn", "no-spot", "no-capabilities", "virtualization-support", "multi-zone", "bundle"}


### PR DESCRIPTION
https://issues.redhat.com/browse/HOSTEDCP-1078

Decommision `hypershift` platform running on hypershift team CI infrastructure in favor of `hypershift-hosted` and `rosa create`.

This allows us to repurpose the `cluster_profile: hypershift` for CI jobs rather than cluster-bot.

@bradmwilliams 