### PR TITLE
fix on Jira workflows

### DIFF
--- a/pkg/slack/events/workflowSubmissionEvents/workflow_handler.go
+++ b/pkg/slack/events/workflowSubmissionEvents/workflow_handler.go
@@ -96,9 +96,7 @@ func handleJiraStep(client workflowSubmit, event *slackevents.WorkflowStepExecut
 		case "issue.key":
 			outgoingOutputs[incomingOutputs.Name] = issue.Key
 		case "issue.link":
-			outgoingOutputs[incomingOutputs.Name] = issue.Self
-		case "issue.summary":
-			outgoingOutputs[incomingOutputs.Name] = issue.Fields.Summary
+			outgoingOutputs[incomingOutputs.Name] = fmt.Sprintf("https://issues.redhat.com/browse/%s", issue.Key)
 		}
 	}
 	options := slack.WorkflowStepCompletedRequestOptionOutput(outgoingOutputs)


### PR DESCRIPTION
Some changes on the Jira API caused a null pointer error (`issue.Fields` is not returned by the API anymore when submitting a bug/story).
The summary will be added to the Slack workflow as part of the message sent to the user. 