### PR TITLE
main,pkg/catalog: change directory to $XDG_RUNTIME_DIR on start

### DIFF
--- a/cmd/ci-chat-bot/main.go
+++ b/cmd/ci-chat-bot/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/openshift/ci-chat-bot/pkg/manager"
 	"github.com/openshift/ci-chat-bot/pkg/slack"
 	"github.com/openshift/ci-chat-bot/pkg/utils"
@@ -131,6 +132,11 @@ func run() error {
 	klog.SetOutput(os.Stderr)
 	// let k8s know that we're alive
 	health := pjutil.NewHealthOnPort(opt.InstrumentationOptions.HealthPort)
+
+	// change directory to writable XDG_RUNTIME_DIR for catalog build caching purposes
+	if err := os.Chdir(xdg.RuntimeDir); err != nil {
+		return fmt.Errorf("couldn't change directory to $XDG_RUNTIME_DIR (%s): %w", xdg.RuntimeDir, err)
+	}
 
 	if err := opt.Validate(); err != nil {
 		return fmt.Errorf("unable to validate program arguments: %w", err)

--- a/pkg/catalog/registry/image.go
+++ b/pkg/catalog/registry/image.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/adrg/xdg"
 	registryimage "github.com/operator-framework/operator-registry/pkg/image"
 	"github.com/operator-framework/operator-registry/pkg/image/containerdregistry"
 	log "github.com/sirupsen/logrus"
@@ -34,12 +33,16 @@ func ExtractBundleImage(ctx context.Context, logger *log.Entry, image string, lo
 	}
 	// Use a temp directory for bundle files. This will likely be removed by
 	// the caller.
-	bundleDir, err := os.MkdirTemp(xdg.RuntimeDir, "bundle-")
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	bundleDir, err := os.MkdirTemp(wd, "bundle-")
 	if err != nil {
 		return "", err
 	}
 	// This should always work, but if it doesn't bundleDir is still valid.
-	if dir, err := filepath.Rel(xdg.RuntimeDir, bundleDir); err == nil {
+	if dir, err := filepath.Rel(wd, bundleDir); err == nil {
 		bundleDir = dir
 	}
 


### PR DESCRIPTION
This should fix permissions errors experienced by the ci-chat-bot production instance when loading and processing bundle images.