### PR TITLE
Prevent panic if/when no Role ARN returned from API

### DIFF
--- a/pkg/manager/rosa.go
+++ b/pkg/manager/rosa.go
@@ -61,7 +61,7 @@ func (m *jobManager) createRosaCluster(providedVersion, slackID, slackChannel st
 
 	// Find all installer roles in the current account using AWS resource tags
 	foundRoleARNs, err := m.rClient.AWSClient.FindRoleARNs(aws.InstallerAccountRole, minor)
-	if err != nil {
+	if err != nil || foundRoleARNs == nil || len(foundRoleARNs) == 0 {
 		metrics.RecordError(errorRosaAWS, m.errorMetric)
 		return nil, "", fmt.Errorf("Failed to find %s role: %s", role.Name, err)
 	}


### PR DESCRIPTION
OSD tags their IAM Policies with the support version of OpenShift that the policy is allowed to install:

Policy: `ManagedOpenShift-Installer-Role-Policy`
Tag: `rosa_openshift_version`: `4.13`

When a user asked for a version that is supported, but greater than the tag value, we panic because the API returns a `nil` slice with no error. :disappointed: 

This PR checks for these cases and errors accordingly.