### PR TITLE
cluster-bot now runs on Internal Red Hat workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ci-chat-bot (aka cluster-bot)
 The **@cluster-bot** is a Slack App that allows users the ability to launch and test OpenShift Clusters from any existing custom built releases.
 
-The App is currently running in the CoreOS slack workspace. To begin using the cluster-bot: Select the `+` in the `Apps` section, to `Browse Apps`, search for `cluster-bot`, and then select its tile.
+The App is currently running in the Red Hat Internal slack workspace. To begin using the cluster-bot: Select the `+` in the `Apps` section, to `Browse Apps`, search for `cluster-bot`, and then select its tile.
 You'll be placed in a new channel with the App, and you'll be ready to begin launching clusters!
 
 To see the available commands, type `help`.


### PR DESCRIPTION
I just started using cluster-bot and found the documentation still referred to the former CoreOS workspace.