### PR TITLE
Disable deleting clusters with `best_effort` option

### DIFF
--- a/pkg/manager/rosa.go
+++ b/pkg/manager/rosa.go
@@ -296,7 +296,7 @@ func (m *jobManager) createRosaCluster(providedVersion, slackID, slackChannel st
 
 func (m *jobManager) deleteCluster(clusterID string) error {
 	klog.Infof("Deleting cluster '%s'", clusterID)
-	_, err := m.rClient.OCMClient.DeleteCluster(clusterID, true, m.rClient.Creator)
+	_, err := m.rClient.OCMClient.DeleteCluster(clusterID, false, m.rClient.Creator)
 	if err != nil {
 		metrics.RecordError(errorRosaDelete, m.errorMetric)
 		return fmt.Errorf("%s", err)


### PR DESCRIPTION
I wasn't really sure what `best_effort` meant in the new `DeleteCluster` API and it turns out that it has a couple nasty side effects:
1. It sends an email warning you that a "force" delete is happening for **EVERY** cluster
2. It has the very real possibility of orphaning resources in our account

So, I'm going to disable it for now.  If/when we have issues, we should open an OHSS ticket and let the SRE's sort it out.