### PR TITLE
Set default controller-runtime logger

### DIFF
--- a/cmd/ci-chat-bot/main.go
+++ b/cmd/ci-chat-bot/main.go
@@ -3,10 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/go-logr/logr"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"strings"
 	"time"
 
@@ -110,6 +112,9 @@ func run() error {
 		ConfigResolver:    "http://config.ci.openshift.org/config",
 		KubernetesOptions: prowflagutil.KubernetesOptions{NOInClusterConfigDefault: true},
 	}
+
+	// Initialize a standard logger for k8s controller-runtime
+	ctrlruntimelog.SetLogger(logr.New(ctrlruntimelog.NullLogSink{}))
 
 	pflag.StringVar(&opt.ConfigResolver, "config-resolver", opt.ConfigResolver, "A URL pointing to a config resolver for retrieving ci-operator config. You may pass a location on disk with file://<abs_path_to_ci_operator_config>")
 	pflag.StringVar(&opt.ForcePROwner, "force-pr-owner", opt.ForcePROwner, "Make the supplied user the owner of all PRs for access control purposes.")

--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 	github.com/fvbommel/sortorder v1.0.1 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-logr/logr v1.2.4
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect


### PR DESCRIPTION
The following stack trace has been firing in our logs for some time:
```
controller-runtime] log.SetLogger(...) was never called, logs will not be displayed:
goroutine 2015 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:24 +0x65
sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	sigs.k8s.io/controller-runtime@v0.15.0/pkg/log/log.go:59 +0xbd
sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0xc0004c4700, {0x3be9b06, 0x14})
	sigs.k8s.io/controller-runtime@v0.15.0/pkg/log/deleg.go:147 +0x4c
github.com/go-logr/logr.Logger.WithName({{0x42f44a0, 0xc0004c4700}, 0x0}, {0x3be9b06?, 0xc074a98b60?})
	github.com/go-logr/logr@v1.2.4/logr.go:336 +0x46
sigs.k8s.io/controller-runtime/pkg/client.newClient(0xc001bbe000, {0x0, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	sigs.k8s.io/controller-runtime@v0.15.0/pkg/client/client.go:115 +0xb4
sigs.k8s.io/controller-runtime/pkg/client.New(0xc05be5a000?, {0x0, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	sigs.k8s.io/controller-runtime@v0.15.0/pkg/client/client.go:101 +0x85
github.com/openshift/ci-chat-bot/pkg/manager.(*jobManager).setupAccessRBAC.func1()
	github.com/openshift/ci-chat-bot/pkg/manager/prow.go:1037 +0x98
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0x0?)
	k8s.io/apimachinery@v0.27.2/pkg/util/wait/wait.go:145 +0x4d
k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff({0x77359400, 0x4000000000000000, 0x0, 0xa, 0x0}, 0x33?)
	k8s.io/apimachinery@v0.27.2/pkg/util/wait/backoff.go:461 +0x5f
github.com/openshift/ci-chat-bot/pkg/manager.(*jobManager).setupAccessRBAC(0xc078134a20?, 0xc077f6eea0, {0xc03dae1d00?, 0x0?})
	github.com/openshift/ci-chat-bot/pkg/manager/prow.go:1028 +0x97
created by github.com/openshift/ci-chat-bot/pkg/manager.(*jobManager).waitForJob
	github.com/openshift/ci-chat-bot/pkg/manager/prow.go:1064 +0x205
```
This PR should address the underlying cause.