### PR TITLE
Get ROSA cluster admin username from args

### DIFF
--- a/cmd/ci-chat-bot/main.go
+++ b/cmd/ci-chat-bot/main.go
@@ -3,14 +3,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/go-logr/logr"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
-	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"strings"
 	"time"
+
+	"github.com/go-logr/logr"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/adrg/xdg"
 	"github.com/openshift/ci-chat-bot/pkg/manager"
@@ -69,12 +70,13 @@ type options struct {
 	leaseServerCredentialsFile string
 	leaseClient                manager.LeaseClient
 
-	rosaClusterLimit       int
-	rosaSubnetListPath     string
-	rosaOIDCConfigId       string
-	rosaBillingAccount     string
-	overrideLaunchLabel    string
-	overrideRosaSecretName string
+	rosaClusterLimit         int
+	rosaClusterAdminUsername string
+	rosaSubnetListPath       string
+	rosaOIDCConfigId         string
+	rosaBillingAccount       string
+	overrideLaunchLabel      string
+	overrideRosaSecretName   string
 
 	jiraOptions prowflagutil.JiraOptions
 }
@@ -127,6 +129,7 @@ func run() error {
 	pflag.StringVar(&opt.overrideLaunchLabel, "override-launch-label", "", "Override the default launch label for jobs. Used for local debugging.")
 	pflag.StringVar(&opt.overrideRosaSecretName, "override-rosa-secret-name", "", "Override the default secret name for rosa cluster tracking. Used for local debugging.")
 	pflag.IntVar(&opt.rosaClusterLimit, "rosa-cluster-limit", 15, "Maximum number of ROSA clusters that can exist at the same time. Set to 0 for no limit.")
+	pflag.StringVar(&opt.rosaClusterAdminUsername, "rosa-cluster-admin-username", "cluster-admin", "Admin username of a ROSA cluster")
 	pflag.StringVar(&opt.rosaSubnetListPath, "rosa-subnetlist-path", "", "Path to list of comma-separated subnets to use for ROSA hosted clusters.")
 	pflag.StringVar(&opt.rosaOIDCConfigId, "rosa-oidcConfigId-path", "", "Path to the OIDC configuration ID")
 	pflag.StringVar(&opt.rosaBillingAccount, "rosa-billingAccount-path", "", "Path to the Billing Account ID.")
@@ -288,6 +291,7 @@ func run() error {
 		rosaSecretClient,
 		&rosaSubnets,
 		opt.rosaClusterLimit,
+		opt.rosaClusterAdminUsername,
 		clusterBotMetrics.ErrorRate,
 		strings.ReplaceAll(string(rosaOidcConfigId), "\n", ""),
 		strings.ReplaceAll(string(rosaBillingAccount), "\n", ""),

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -122,6 +122,7 @@ func NewJobManager(
 	rosaSecretClient typedcorev1.SecretInterface,
 	rosaSubnetList *RosaSubnets,
 	rosaClusterLimit int,
+	rosaClusterAdminUsername string,
 	errorRate *prometheus.CounterVec,
 	rosaOidcConfigId string,
 	rosaBillingAccount string,
@@ -145,16 +146,17 @@ func NewJobManager(
 
 		lClient: lClient,
 
-		hiveConfigMapClient: hiveConfigMapClient,
-		rosaSecretClient:    rosaSecretClient,
-		rClient:             rosaClient,
-		maxRosaAge:          6 * time.Hour,
-		defaultRosaAge:      6 * time.Hour,
-		rosaSubnets:         rosaSubnetList,
-		rosaClusterLimit:    rosaClusterLimit,
-		rosaOidcConfigId:    rosaOidcConfigId,
-		rosaBillingAccount:  rosaBillingAccount,
-		errorMetric:         errorRate,
+		hiveConfigMapClient:      hiveConfigMapClient,
+		rosaSecretClient:         rosaSecretClient,
+		rClient:                  rosaClient,
+		maxRosaAge:               6 * time.Hour,
+		defaultRosaAge:           6 * time.Hour,
+		rosaSubnets:              rosaSubnetList,
+		rosaClusterLimit:         rosaClusterLimit,
+		rosaClusterAdminUsername: rosaClusterAdminUsername,
+		rosaOidcConfigId:         rosaOidcConfigId,
+		rosaBillingAccount:       rosaBillingAccount,
+		errorMetric:              errorRate,
 	}
 	m.muJob.running = make(map[string]struct{})
 	initializeErrorMetrics(m.errorMetric)

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -193,11 +193,12 @@ type jobManager struct {
 		lock     sync.RWMutex
 		versions []string
 	}
-	rosaClusterLimit   int
-	rosaSubnets        *RosaSubnets
-	rosaErrorReported  sets.Set[string]
-	rosaOidcConfigId   string
-	rosaBillingAccount string
+	rosaClusterLimit         int
+	rosaClusterAdminUsername string
+	rosaSubnets              *RosaSubnets
+	rosaErrorReported        sets.Set[string]
+	rosaOidcConfigId         string
+	rosaBillingAccount       string
 
 	maxRosaAge       time.Duration
 	defaultRosaAge   time.Duration


### PR DESCRIPTION
Test `ci/prow/security` is perma failing as Snyk complains about the username being hardcoded.
An example [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-chat-bot/444/pull-ci-openshift-ci-chat-bot-master-security/1744266810842157056):
```
Starting snyk code scan
Testing /go/src/github.com/openshift/ci-chat-bot ...
 ✗ [Low] Use of Hardcoded Credentials
   ID: 0f2a5b43-5a82-44cb-9bc4-f71b2bb3d0a2 
   Path: pkg/manager/rosa.go, line 357 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
```