### PR TITLE
Add "workflow-test" command

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -49,8 +49,17 @@
 
    The workflow config file also supports setting base_images for workflows that may require special base images to run as well as an architecture field that will support configuring the CPU architecture for openshift to run on once non-amd64 architectures are supported by the ci-chat-bot (https://github.com/openshift/ci-chat-bot/blob/master/prow.go#L190).
 
+## workflow_test
+1. **What is `workflow_test`?**
 
-2. **How can I make a workflow runnable by the `workflow-launch` command**
+   Similar to `workflow_launch`, but preserves `test` stage in the workflow. This is useful to run a particular workflow for a set of pull-requests or with varied parameters.
+
+   The definition of the command is as follows:
+
+   `workflow-test {workflow_name} {image_or_version_or_prs} {parameters}`
+
+
+2. **How can I make a workflow runnable by `workflow-*` commands**
 
    1. Make a PR editing the
       [workflows-config.yaml](https://github.com/openshift/release/blob/master/core-services/ci-chat-bot/workflows-config.yaml)
@@ -81,5 +90,3 @@ clusters:
     - `http_proxy=145.40.68.183:8213 https_proxy=145.40.68.183:8213 curl -L https://console-openshift-console.apps.ostest.test.metalkube.org/ -v`
     - `curl -kvx http://145.40.68.183:8213 https://console-openshift-console.apps.ostest.test.metalkube.org/dashboards`
     - `export http_proxy=145.40.68.183:8213 && export https_proxy=145.40.68.183:8213 && oc login -u kubeadmin -p <password> https://api.ostest.test.metalkube.org:6443`
-
-

--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -437,12 +437,13 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 	_, targetName, _ := configContainsVariant(job.JobParams, job.Platform, sourceEnv.Value, job.Mode)
 
 	// For workflows, we configure the tests we run; for others, we need to load and modify the tests
-	if job.Mode == JobTypeWorkflowLaunch || job.Mode == JobTypeWorkflowUpgrade {
+	if job.Mode == JobTypeWorkflowLaunch || job.Mode == JobTypeWorkflowUpgrade || job.Mode == JobTypeWorkflowTest {
 		// use "launch" test name to identify proper cluster profile
 		var profile citools.ClusterProfile
 		for _, test := range sourceConfig.Tests {
 			if test.As == "launch" {
 				profile = test.MultiStageTestConfiguration.ClusterProfile
+				break
 			}
 		}
 		environment := citools.TestEnvironment{}

--- a/pkg/prow/prow.go
+++ b/pkg/prow/prow.go
@@ -3,9 +3,10 @@ package prow
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	"github.com/openshift/ci-chat-bot/pkg/utils"
 	"k8s.io/test-infra/prow/pjutil"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/slack/events/apphome/apphome.go
+++ b/pkg/slack/events/apphome/apphome.go
@@ -2,6 +2,7 @@ package apphome
 
 import (
 	"encoding/json"
+
 	"github.com/openshift/ci-chat-bot/pkg/slack/events"
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
@@ -106,6 +107,24 @@ const homeJson = `
 				},
 				"value": "workflow_launch",
 				"action_id": "workflow_launch",
+				"style": "primary"
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "Start the test using the requested workflow from an image,release or built PRs"
+			},
+			"accessory": {
+				"type": "button",
+				"text": {
+					"type": "plain_text",
+					"text": "Workflow-Test",
+					"emoji": true
+				},
+				"value": "workflow_test",
+				"action_id": "workflow_test",
 				"style": "primary"
 			}
 		},

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -139,6 +139,11 @@ func (b *Bot) SupportedCommands() []parser.BotCommand {
 			Example:     "workflow-launch openshift-e2e-gcp-windows-node 4.15 gcp",
 			Handler:     WorkflowLaunch,
 		}),
+		parser.NewBotCommand("workflow-test <name> <image_or_version_or_prs> <parameters>", &parser.CommandDefinition{
+			Description: "Start the test using the requested workflow from an image or release or built PRs. The from argument may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org.",
+			Example:     "workflow-test openshift-e2e-gcp 4.15",
+			Handler:     WorkflowTest,
+		}),
 		parser.NewBotCommand("workflow-upgrade <name> <from_image_or_version_or_prs> <to_image_or_version_or_prs> <parameters>", &parser.CommandDefinition{
 			Description: "Run a custom upgrade using the requested workflow from an image or release or built PRs to a specified version/image/pr from https://amd64.ocp.releases.ci.openshift.org. ",
 			Example:     "workflow-upgrade openshift-upgrade-azure-ovn 4.14 4.15 azure",


### PR DESCRIPTION
This adds new "workflow-test" command, which is similar to `workflow-launch`, but doesn't mutate tests.

This is useful to run a particular workflow for a set of pull-requests or with varied parameters