### PR TITLE
NO-JIRA: Introduce new oc get execution command

### DIFF
--- a/pkg/slack/actions.go
+++ b/pkg/slack/actions.go
@@ -418,6 +418,21 @@ func WorkflowUpgrade(client *slack.Client, jobManager manager.JobManager, event 
 	return msg
 }
 
+func ExecuteOC(client *slack.Client, jobManager manager.JobManager, event *slackevents.MessageEvent, properties *parser.Properties) string {
+	cluster, password := jobManager.GetROSACluster(event.User)
+	if cluster != nil {
+		ExecuteOCOnRosa(client, cluster, password, event.Text)
+		return ""
+	}
+	job, err := jobManager.GetLaunchJob(event.User)
+	if err != nil {
+		return err.Error()
+	}
+	job.RequestedChannel = event.Channel
+	ExecuteOCOnJob(client, job, event.Text)
+	return ""
+}
+
 func RosaCreate(client *slack.Client, jobManager manager.JobManager, event *slackevents.MessageEvent, properties *parser.Properties) string {
 	from, err := ParseImageInput(properties.StringParam("version", ""))
 	if err != nil {


### PR DESCRIPTION
This PR introduces new command to execute readonly oc commands in Slack against launched clusters by using the generated sole kubeconfig. Currently, only `oc get` will be allowed to collect
some feedback and in the future, this can be extended.

I'd like to note that this is just a PoC and haven't been tested yet.