### PR TITLE
Adding `ci_chat_bot_rosa_cluster_count` metric

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -57,6 +57,7 @@ func init() {
 	prometheus.MustRegister(rosaConsoleTimeMetric)
 	prometheus.MustRegister(rosaReadyToConsoleTimeMetric)
 	prometheus.MustRegister(rosaSyncTimeMetric)
+	prometheus.MustRegister(rosaClustersMetric)
 }
 
 const (
@@ -275,7 +276,7 @@ func paramsToString(params map[string]string) string {
 
 func (m *jobManager) rosaSync() error {
 	start := time.Now()
-	// wrap Observe function into inline function so that time.Since doesn't get immediately evauluated
+	// wrap Observe function into inline function so that time.Since doesn't get immediately evaluated
 	defer func() { rosaSyncTimeMetric.Observe(time.Since(start).Seconds()) }()
 	klog.Infof("Getting ROSA clusters")
 	clusterList, err := m.rClient.OCMClient.GetAllClusters(m.rClient.Creator)
@@ -284,6 +285,7 @@ func (m *jobManager) rosaSync() error {
 		klog.Warningf("Failed to get clusters: %v", err)
 	}
 	klog.Infof("Found %d rosa clusters", len(clusterList))
+	rosaClustersMetric.Set(float64(len(clusterList)))
 
 	m.rosaClusters.lock.RLock()
 	defer m.rosaClusters.lock.RUnlock()

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -110,6 +110,13 @@ var rosaSyncTimeMetric = prometheus.NewHistogram(
 	},
 )
 
+var rosaClustersMetric = prometheus.NewGauge(
+	prometheus.GaugeOpts{
+		Name: "ci_chat_bot_rosa_cluster_count",
+		Help: "cluster bot number of rosa clusters",
+	},
+)
+
 type EnvVar struct {
 	name      string
 	value     string


### PR DESCRIPTION
Introducing a simple Gauge to track how many Rosa clusters we are running at any given time.  The end goal will be a graph on our Grafana dashboard to visualize our Rosa consumption over time.