### PR TITLE
Resolve Stable releases for multi-arch hypershift-hosted

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1054,8 +1054,11 @@ func findNewestStableImageSpecTagBySemanticMajor(is *imagev1.ImageStream, majorM
 		return nil
 	}
 	archSuffix := ""
-	if architecture == "arm64" {
+	switch architecture {
+	case "arm64":
 		archSuffix = "-arm64"
+	case "multi":
+		archSuffix = "-multi"
 	}
 	var candidates semver.Versions
 	for _, tag := range is.Spec.Tags {


### PR DESCRIPTION
Now that the `hypershift-hosted` environment is utilizing multi-arch payloads, we need to be able to resolve GA releases, like: `launch 4.15 hypershift-hosted`.  Currently, that will return: `no stable, official prerelease, or nightly version published yet for 4.15`.
This PR adds the necessary `archSuffix` to resolve the releases properly.