### PR TITLE
Allowing `workflow-launch` to create multi-arch `hypershift-hosted` clusters

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1424,7 +1424,9 @@ func (m *jobManager) resolveToJob(req *JobRequest) (*Job, error) {
 		job.Mode = JobTypeWorkflowUpgrade
 	case JobTypeWorkflowLaunch:
 		if req.Architecture != "amd64" {
-			return nil, fmt.Errorf("workflow launches are not currently supported for non-amd64 releases")
+			if req.Architecture != "multi" && req.Platform != "hypershift-hosted" {
+				return nil, fmt.Errorf("workflow launches are not currently supported for non-amd64 releases")
+			}
 		}
 		if len(jobInputs) != 1 {
 			return nil, fmt.Errorf("launching a cluster requires one image, version, or pull request")

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -229,6 +229,9 @@ func GetPlatformArchFromWorkflowConfig(workflowConfig *manager.WorkflowConfig, n
 			}
 		}
 	}
+	if platform == "hypershift-hosted" {
+		architecture = "multi"
+	}
 	return platform, architecture, nil
 }
 


### PR DESCRIPTION
Folks have been struggling to launch `hypershift-hosted` clusters via `workflow-launch` because the way we select the underlying job that will house the injected workflow configuration.  This fix will allow us to pass the `hypershift-hosted` platform directly through to the job selector and we should pick up the correctly defined job and then inject the specified workflow.

This PR is only the first part of the fix.  Once merged, I will chase it with a change to the workflow-config.yaml, in openshift/release, to update the `hypershift-hostedcluster-workflow`'s  platform to: `hypershift-hosted`.