### PR TITLE
Return "" to avoid dereferencing a null value

### DIFF
--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -169,7 +169,8 @@ func (b *Bot) SupportedCommands() []parser.BotCommand {
 func GetUserName(client *slack.Client, userID string) string {
 	user, err := client.GetUserInfo(userID)
 	if err != nil {
-		klog.Warningf("Failed to get the User details for UserID: %s", userID)
+		klog.Warningf("Failed to get the User Info for UserID: %s", userID)
+		return ""
 	}
 	if strings.HasSuffix(user.Profile.Email, "@redhat.com") {
 		return strings.TrimSuffix(user.Profile.Email, "@redhat.com")

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -169,7 +169,7 @@ func (b *Bot) SupportedCommands() []parser.BotCommand {
 func GetUserName(client *slack.Client, userID string) string {
 	user, err := client.GetUserInfo(userID)
 	if err != nil {
-		klog.Warningf("Failed to get the User Info for UserID: %s", userID)
+		klog.Warningf("Failed to get the User Info for UserID: %s, %v", userID, err)
 		return ""
 	}
 	if strings.HasSuffix(user.Profile.Email, "@redhat.com") {


### PR DESCRIPTION
I was able to reproduce a crash when sending `launch` in the chat to the cluster-bot in my development environment.  This PR avoids the crash.  I also modified the message to make it different than the message below it to make it easier to tell what code path was taken.