### PR TITLE
Replace curly double quotes with an empty string

### DIFF
--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -240,6 +240,7 @@ func GetPlatformArchFromWorkflowConfig(workflowConfig *manager.WorkflowConfig, n
 func BuildJobParams(params string) (map[string]string, error) {
 	var splitParams []string
 	if len(params) > 0 {
+		params = strings.ReplaceAll(strings.ReplaceAll(params, "“", ""), "”", "")
 		if !strings.Contains(params, "\"") {
 			return nil, fmt.Errorf("unable to parse `%s` for parameters. Please ensure that you're using double quotes to enclose variables", params)
 		}

--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -26,12 +26,6 @@ func TestBuildJobParams(t *testing.T) {
 			errorString: "",
 		},
 		{
-			name:        "IncorrectlyQuotedParameter",
-			params:      "“KEY1=VALUE1”",
-			expected:    nil,
-			errorString: "unable to parse `“KEY1=VALUE1”` for parameters. Please ensure that you're using double quotes to enclose variables",
-		},
-		{
 			name:        "IncorrectlyDeliminatedParameter",
 			params:      "\"KEY1:VALUE1\"",
 			expected:    nil,


### PR DESCRIPTION
This PR addresses the issue that occurs when the user enables the 'Use smart quotes and dashes' option in the keyboard settings. As a result, when the user types multiple environment variables with double quotes, the system keyboard inputs curly double quotes instead of straight double quotes. 

This leads to an error message: 'unable to interpret "AUX_HOST=openshift-qe-metal-ci.arm.eng.rdu2.redhat.com","DISCONNECTED=false","RESERVE_BOOTSTRAP=false","architecture=arm64 as a parameter. Please ensure that all parameters are in the form of KEY=VALUE'