### PR TITLE
Strip whitespace from location tokens

### DIFF
--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -434,10 +434,12 @@ func ParseImageInput(input string) ([]string, error) {
 	}
 	input = utils.StripLinks(input)
 	parts := strings.Split(input, ",")
-	for _, part := range parts {
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
 		if len(part) == 0 {
 			return nil, fmt.Errorf("image inputs must not contain empty items")
 		}
+		parts[i] = part // store trimmed variant
 	}
 	return parts, nil
 }


### PR DESCRIPTION
Currently, the following invocation will fail due to the space after the comma in the CSV list:

```
build 4.18, openshift-release/csi-operator#275
```

Start stripping whitespace and allow this to succeed.
