### PR TITLE
Adding `origin` SCOS images for image version resolution

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -909,7 +909,8 @@ func (m *jobManager) ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp", Imagestream: "release"})
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp", Imagestream: "4-dev-preview"})
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "origin", Imagestream: "release"})
-		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "origin", Imagestream: "scos-release"})
+		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "origin", Imagestream: "release-scos"})
+		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "origin", Imagestream: "release-scos-next"})
 	case "arm64":
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp-arm64", Imagestream: "release-arm64", ArchSuffix: "-arm64"})
 		imagestreams = append(imagestreams, namespaceAndStream{Namespace: "ocp-arm64", Imagestream: "4-dev-preview-arm64", ArchSuffix: "-arm64"})


### PR DESCRIPTION
When OKD introduced the new SCOS release imagestreams, we never updated the logic to handle release version resolution to pick up these new version.  While it was still possible to resolve these images via a full PullSpec, like:
```
test upgrade quay.io/okd/scos-release:4.16.0-0.okd-scos-2024-08-21-155613 quay.io/okd/scos-release:4.16.0-0.okd-scos-2024-09-24-151747 aws
```
The problem is that these upgrade jobs would never be picked up by the release-controller for the upgrade graph.
This PR adds support for the `release-scos` and `release-scos-next` imagestreams.

Once this PR merges, it will be possible to launch OKD upgrade jobs like:
```
test upgrade 4.16.0-0.okd-scos-2024-08-21-155613 4.16.0-0.okd-scos-2024-09-24-151747 aws
```
and these jobs will be decorated with the correct labels and annotations for the release-controller to pick up the results for the upgrade graph.