### PR TITLE
manager,slack: various improvements to mce feature

### DIFF
--- a/hack/run.sh
+++ b/hack/run.sh
@@ -7,19 +7,16 @@ if [[ -z $BOT_SIGNING_SECRET ]]; then echo "BOT_SIGNING_SECRET var must be set";
 
 tmp_dir=$(mktemp -d)
 tmp_kube=$tmp_dir/kubeconfigs
-tmp_build=$tmp_dir/kubeconfigs/build
-tmp_dpcr=$tmp_dir/kubeconfigs/dpcr
 mkdir -p $tmp_kube
-mkdir -p $tmp_dpcr
 tmp_boskos=$tmp_dir/boskos
 tmp_subnets=$tmp_dir/subnets
 trap 'rm -rf $tmp_dir' EXIT
 
-oc --context app.ci -n ci extract secrets/ci-chat-bot-kubeconfigs --to=${tmp_build} --confirm
+oc --context app.ci -n ci extract secrets/ci-chat-bot-kubeconfigs --to=${tmp_kube} --confirm
 oc --context app.ci -n ci get secrets boskos-credentials -ogo-template={{.data.credentials}} | base64 -d > $tmp_boskos
 oc --context app.ci -n ci get secrets ci-chat-bot-slack-app --template='{{index .data "rosa-subnet-ids"}}' | base64 -d > $tmp_subnets
-oc --context app.ci -n ci get secrets ci-chat-bot-slack-app --template='{{index .data "sa.ci-chat-bot-mce.dpcr.config"}}' | base64 -d > $tmp_dpcr/sa.ci-chat-bot-mce.dpcr.config
-oc --context app.ci -n ci get secrets ci-chat-bot-slack-app --template='{{index .data "sa.ci-chat-bot-mce.dpcr.token.txt"}}' | base64 -d > $tmp_dpcr/sa.ci-chat-bot-mce.dpcr.token.txt
+oc --context app.ci -n ci get secrets ci-chat-bot-slack-app --template='{{index .data "sa.ci-chat-bot-mce.dpcr.config"}}' | base64 -d > $tmp_kube/sa.ci-chat-bot-mce.dpcr.config
+oc --context app.ci -n ci get secrets ci-chat-bot-slack-app --template='{{index .data "sa.ci-chat-bot-mce.dpcr.token.txt"}}' | base64 -d > $tmp_kube/sa.ci-chat-bot-mce.dpcr.token.txt
 
 work_dir=$(readlink -f $(dirname $0)/..)
 make

--- a/pkg/manager/mce.go
+++ b/pkg/manager/mce.go
@@ -224,7 +224,7 @@ func (m *jobManager) createManagedCluster(providedImageSet, platform, user, slac
 		return nil, fmt.Errorf("failed to create managed cluster object: %v", err)
 	}
 
-	attemptLimit := int32(1)
+	attemptLimit := int32(2)
 	clusterDeployment := hivev1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -296,8 +296,8 @@ type JobManager interface {
 	CreateMceCluster(user, channel, platform, imageset string, duration time.Duration) (string, error)
 	DeleteMceCluster(user, clusterName string) (string, error)
 	GetManagedClustersForUser(user string) (map[string]*clusterv1.ManagedCluster, map[string]*hivev1.ClusterDeployment, map[string]*hivev1.ClusterProvision, map[string]string, map[string]string)
-	ListManagedClusters() string
-	ListImagesets() string
+	ListManagedClusters(user string) string
+	ListMceVersions() string
 	GetMceUserConfig() *MceConfig
 }
 

--- a/pkg/slack/actions.go
+++ b/pkg/slack/actions.go
@@ -507,7 +507,7 @@ func RosaDescribe(client *slack.Client, jobManager manager.JobManager, event *sl
 }
 
 func MceCreate(client *slack.Client, jobManager manager.JobManager, event *slackevents.MessageEvent, properties *parser.Properties) string {
-	from, err := ParseImageInput(properties.StringParam("imageset", ""))
+	from, err := ParseImageInput(properties.StringParam("version", ""))
 	if err != nil {
 		return err.Error()
 	}
@@ -567,9 +567,16 @@ func MceDelete(client *slack.Client, jobManager manager.JobManager, event *slack
 }
 
 func MceImageSets(client *slack.Client, jobManager manager.JobManager, event *slackevents.MessageEvent, properties *parser.Properties) string {
-	return jobManager.ListImagesets()
+	return jobManager.ListMceVersions()
 }
 
 func MceList(client *slack.Client, jobManager manager.JobManager, event *slackevents.MessageEvent, properties *parser.Properties) string {
-	return jobManager.ListManagedClusters()
+	all, err := ParseImageInput(properties.StringParam("all", ""))
+	if err != nil {
+		return err.Error()
+	}
+	if len(all) > 0 && all[0] == "all" {
+		return jobManager.ListManagedClusters("")
+	}
+	return jobManager.ListManagedClusters(event.User)
 }


### PR DESCRIPTION
- `mce list` now only shows clusters requested by user. `mce list all` can be used to show all users' clusters.
- `mce sync` now uses a list with label selector to find ClusterProvisions, avoiding issues where the reference was not added to the deployment
- change `mce imagesets` to `mce lookup` for consistency
- upload install log from cluster provision in case of provisioning error
- increase install attempt limit to 2