### PR TITLE
manager: keep prowjob scheduler in order to use cache

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -150,6 +150,7 @@ func NewJobManager(
 		githubClient:     githubClient,
 		prowConfigLoader: prowConfigLoader,
 		prowClient:       prowClient,
+		prowScheduler:    strategy.Get(prowConfigLoader.Config(), logrus.WithField("interface", "scheduler")),
 		prowLister:       prowInformer.Lister(),
 		imageClient:      imageClient,
 		clusterClients:   buildClusterClientConfigMap,
@@ -2374,7 +2375,7 @@ func (m *jobManager) LookupRosaInputs(versionPrefix string) (string, error) {
 }
 
 func (m *jobManager) schedule(pj *prowapiv1.ProwJob) (string, error) {
-	cluster, err := strategy.Get(m.prowConfigLoader.Config(), logrus.WithField("interface", "scheduler")).Schedule(context.TODO(), pj)
+	cluster, err := m.prowScheduler.Schedule(context.TODO(), pj)
 	if err != nil {
 		return "", fmt.Errorf("Failed to schedule job %s: %v", pj.Name, err)
 	}

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -23,6 +23,7 @@ import (
 	prowjobClient "sigs.k8s.io/prow/pkg/client/clientset/versioned/typed/prowjobs/v1"
 	prowjobLister "sigs.k8s.io/prow/pkg/client/listers/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/scheduler/strategy"
 )
 
 const (
@@ -173,6 +174,7 @@ type jobManager struct {
 	prowConfigLoader    prow.ProwConfigLoader
 	prowClient          prowjobClient.ProwV1Interface
 	prowLister          prowjobLister.ProwJobLister
+	prowScheduler       strategy.Interface
 	imageClient         imageclientset.Interface
 	hiveConfigMapClient corev1.ConfigMapInterface
 	clusterClients      utils.BuildClusterClientConfigMap


### PR DESCRIPTION
Store a scheduler interface as part of the manager struct. This allows the scheduler to use its built in cache, whose timeout is defined in the prow config (currently 10 minutes). The chat-bot likely won't make too much use of it, but it can't hurt to potentially reduce the load on the scheduler.