### PR TITLE
slack: bump library and use UploadFileV2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/openshift/oc v0.0.0-alpha.0.0.20230410203846-b68ac7c39057
 	github.com/operator-framework/operator-registry v1.28.0
 	github.com/sirupsen/logrus v1.9.3
-	github.com/slack-go/slack v0.12.1
+	github.com/slack-go/slack v0.15.0
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -2713,8 +2713,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
-github.com/slack-go/slack v0.12.1 h1:X97b9g2hnITDtNsNe5GkGx6O2/Sz/uC20ejRZN6QxOw=
-github.com/slack-go/slack v0.12.1/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
+github.com/slack-go/slack v0.15.0 h1:LE2lj2y9vqqiOf+qIIy0GvEoxgF1N5yLGZffmEZykt0=
+github.com/slack-go/slack v0.15.0/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1819,7 +1819,7 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 	job.JobName = prowJob.Spec.Job
 	job.BuildCluster, err = m.schedule(prowJob)
 	if err != nil {
-		klog.Errorf(err.Error())
+		klog.Error(err.Error())
 		job.BuildCluster = prowJob.Spec.Cluster
 	}
 

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -462,14 +462,13 @@ func NotifyJob(client *slack.Client, job *manager.Job) {
 }
 
 func SendKubeConfig(client *slack.Client, channel, contents, comment, identifier string) {
-	params := slack.FileUploadParameters{
+	params := slack.UploadFileV2Parameters{
 		Content:        contents,
-		Channels:       []string{channel},
+		Channel:        channel,
 		Filename:       fmt.Sprintf("cluster-bot-%s.kubeconfig", identifier),
-		Filetype:       "text",
 		InitialComment: comment,
 	}
-	_, err := client.UploadFile(params)
+	_, err := client.UploadFileV2(params)
 	if err != nil {
 		klog.Errorf("error: unable to send attachment with message: %v", err)
 		return
@@ -599,14 +598,13 @@ func NotifyMce(client *slack.Client, cluster *clusterv1.ManagedCluster, clusterD
 			}
 			return
 		}
-		params := slack.FileUploadParameters{
+		params := slack.UploadFileV2Parameters{
 			Content:        *clusterProvision.Spec.InstallLog,
-			Channels:       []string{channel},
+			Channel:        channel,
 			Filename:       fmt.Sprintf("%s-error.txt", cluster.Name),
-			Filetype:       "text",
 			InitialComment: message,
 		}
-		_, err := client.UploadFile(params)
+		_, err := client.UploadFileV2(params)
 		if err != nil {
 			klog.Errorf("error: unable to send attachment with message: %v", err)
 			return

--- a/vendor/github.com/slack-go/slack/.gitignore
+++ b/vendor/github.com/slack-go/slack/.gitignore
@@ -1,3 +1,4 @@
 *.test
 *~
 .idea/
+/vendor/

--- a/vendor/github.com/slack-go/slack/apps.go
+++ b/vendor/github.com/slack-go/slack/apps.go
@@ -19,11 +19,15 @@ type EventAuthorization struct {
 	IsEnterpriseInstall bool   `json:"is_enterprise_install"`
 }
 
+// ListEventAuthorizations lists authed users and teams for the given event_context.
+// You must provide an app-level token to the client using OptionAppLevelToken.
+// For more details, see ListEventAuthorizationsContext documentation.
 func (api *Client) ListEventAuthorizations(eventContext string) ([]EventAuthorization, error) {
 	return api.ListEventAuthorizationsContext(context.Background(), eventContext)
 }
 
-// ListEventAuthorizationsContext lists authed users and teams for the given event_context. You must provide an app-level token to the client using OptionAppLevelToken. More info: https://api.slack.com/methods/apps.event.authorizations.list
+// ListEventAuthorizationsContext lists authed users and teams for the given event_context with a custom context.
+// Slack API docs: https://api.slack.com/methods/apps.event.authorizations.list
 func (api *Client) ListEventAuthorizationsContext(ctx context.Context, eventContext string) ([]EventAuthorization, error) {
 	resp := &listEventAuthorizationsResponse{}
 
@@ -43,10 +47,14 @@ func (api *Client) ListEventAuthorizationsContext(ctx context.Context, eventCont
 	return resp.Authorizations, nil
 }
 
+// UninstallApp uninstalls your app from a workspace.
+// For more details, see UninstallAppContext documentation.
 func (api *Client) UninstallApp(clientID, clientSecret string) error {
 	return api.UninstallAppContext(context.Background(), clientID, clientSecret)
 }
 
+// UninstallAppContext uninstalls your app from a workspace with a custom context.
+// Slack API docs: https://api.slack.com/methods/apps.uninstall
 func (api *Client) UninstallAppContext(ctx context.Context, clientID, clientSecret string) error {
 	values := url.Values{
 		"client_id":     {clientID},

--- a/vendor/github.com/slack-go/slack/auth.go
+++ b/vendor/github.com/slack-go/slack/auth.go
@@ -22,12 +22,14 @@ func (api *Client) authRequest(ctx context.Context, path string, values url.Valu
 	return response, response.Err()
 }
 
-// SendAuthRevoke will send a revocation for our token
+// SendAuthRevoke will send a revocation for our token.
+// For more details, see SendAuthRevokeContext documentation.
 func (api *Client) SendAuthRevoke(token string) (*AuthRevokeResponse, error) {
 	return api.SendAuthRevokeContext(context.Background(), token)
 }
 
-// SendAuthRevokeContext will send a revocation request for our token to api.revoke with context
+// SendAuthRevokeContext will send a revocation request for our token to api.revoke with a custom context.
+// Slack API docs: https://api.slack.com/methods/auth.revoke
 func (api *Client) SendAuthRevokeContext(ctx context.Context, token string) (*AuthRevokeResponse, error) {
 	if token == "" {
 		token = api.token
@@ -50,12 +52,13 @@ type ListTeamsParameters struct {
 }
 
 // ListTeams returns all workspaces a token can access.
-// More info: https://api.slack.com/methods/admin.teams.list
+// For more details, see ListTeamsContext documentation.
 func (api *Client) ListTeams(params ListTeamsParameters) ([]Team, string, error) {
 	return api.ListTeamsContext(context.Background(), params)
 }
 
-// ListTeams returns all workspaces a token can access with a custom context.
+// ListTeamsContext returns all workspaces a token can access with a custom context.
+// Slack API docs: https://api.slack.com/methods/auth.teams.list
 func (api *Client) ListTeamsContext(ctx context.Context, params ListTeamsParameters) ([]Team, string, error) {
 	values := url.Values{
 		"token": {api.token},

--- a/vendor/github.com/slack-go/slack/block.go
+++ b/vendor/github.com/slack-go/slack/block.go
@@ -18,6 +18,8 @@ const (
 	MBTInput    MessageBlockType = "input"
 	MBTHeader   MessageBlockType = "header"
 	MBTRichText MessageBlockType = "rich_text"
+	MBTCall     MessageBlockType = "call"
+	MBTVideo    MessageBlockType = "video"
 )
 
 // Block defines an interface all block types should implement
@@ -39,6 +41,7 @@ type BlockAction struct {
 	Type                  ActionType          `json:"type"`
 	Text                  TextBlockObject     `json:"text"`
 	Value                 string              `json:"value"`
+	Files                 []File              `json:"files"`
 	ActionTs              string              `json:"action_ts"`
 	SelectedOption        OptionBlockObject   `json:"selected_option"`
 	SelectedOptions       []OptionBlockObject `json:"selected_options"`
@@ -50,6 +53,7 @@ type BlockAction struct {
 	SelectedConversations []string            `json:"selected_conversations"`
 	SelectedDate          string              `json:"selected_date"`
 	SelectedTime          string              `json:"selected_time"`
+	SelectedDateTime      int64               `json:"selected_date_time"`
 	InitialOption         OptionBlockObject   `json:"initial_option"`
 	InitialUser           string              `json:"initial_user"`
 	InitialChannel        string              `json:"initial_channel"`

--- a/vendor/github.com/slack-go/slack/block_call.go
+++ b/vendor/github.com/slack-go/slack/block_call.go
@@ -1,0 +1,23 @@
+package slack
+
+// CallBlock defines data that is used to display a call in slack.
+//
+// More Information: https://api.slack.com/apis/calls#post_to_channel
+type CallBlock struct {
+	Type    MessageBlockType `json:"type"`
+	BlockID string           `json:"block_id,omitempty"`
+	CallID  string           `json:"call_id"`
+}
+
+// BlockType returns the type of the block
+func (s CallBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// NewFileBlock returns a new instance of a file block
+func NewCallBlock(callID string) *CallBlock {
+	return &CallBlock{
+		Type:   MBTCall,
+		CallID: callID,
+	}
+}

--- a/vendor/github.com/slack-go/slack/block_conv.go
+++ b/vendor/github.com/slack-go/slack/block_conv.go
@@ -2,7 +2,6 @@ package slack
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -66,8 +65,14 @@ func (b *Blocks) UnmarshalJSON(data []byte) error {
 			block = &InputBlock{}
 		case "rich_text":
 			block = &RichTextBlock{}
+		case "rich_text_input":
+			block = &RichTextBlock{}
 		case "section":
 			block = &SectionBlock{}
+		case "call":
+			block = &CallBlock{}
+		case "video":
+			block = &VideoBlock{}
 		default:
 			block = &UnknownBlock{}
 		}
@@ -110,8 +115,12 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 		e = &DatePickerBlockElement{}
 	case "timepicker":
 		e = &TimePickerBlockElement{}
+	case "datetimepicker":
+		e = &DateTimePickerBlockElement{}
 	case "plain_text_input":
 		e = &PlainTextInputBlockElement{}
+	case "rich_text_input":
+		e = &RichTextInputBlockElement{}
 	case "email_text_input":
 		e = &EmailTextInputBlockElement{}
 	case "url_text_input":
@@ -128,8 +137,10 @@ func (b *InputBlock) UnmarshalJSON(data []byte) error {
 		e = &RadioButtonsBlockElement{}
 	case "number_input":
 		e = &NumberInputBlockElement{}
+	case "file_input":
+		e = &FileInputBlockElement{}
 	default:
-		return errors.New("unsupported block element type")
+		return fmt.Errorf("unsupported block element type %v", s.TypeVal)
 	}
 
 	if err := json.Unmarshal(a.Element, e); err != nil {
@@ -190,8 +201,12 @@ func (b *BlockElements) UnmarshalJSON(data []byte) error {
 			blockElement = &DatePickerBlockElement{}
 		case "timepicker":
 			blockElement = &TimePickerBlockElement{}
+		case "datetimepicker":
+			blockElement = &DateTimePickerBlockElement{}
 		case "plain_text_input":
 			blockElement = &PlainTextInputBlockElement{}
+		case "rich_text_input":
+			blockElement = &RichTextInputBlockElement{}
 		case "email_text_input":
 			blockElement = &EmailTextInputBlockElement{}
 		case "url_text_input":
@@ -233,6 +248,7 @@ func (a *Accessory) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the Unmarshaller interface for Accessory, so that any JSON
 // unmarshalling is delegated and proper type determination can be made before unmarshal
+// Note: datetimepicker is not supported in Accessory
 func (a *Accessory) UnmarshalJSON(data []byte) error {
 	var r json.RawMessage
 
@@ -293,6 +309,12 @@ func (a *Accessory) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		a.PlainTextInputElement = element.(*PlainTextInputBlockElement)
+	case "rich_text_input":
+		element, err := unmarshalBlockElement(r, &RichTextInputBlockElement{})
+		if err != nil {
+			return err
+		}
+		a.RichTextInputElement = element.(*RichTextInputBlockElement)
 	case "radio_buttons":
 		element, err := unmarshalBlockElement(r, &RadioButtonsBlockElement{})
 		if err != nil {
@@ -424,7 +446,7 @@ func (e *ContextElements) UnmarshalJSON(data []byte) error {
 
 			e.Elements = append(e.Elements, elem.(*ImageBlockElement))
 		default:
-			return errors.New("unsupported context element type")
+			return fmt.Errorf("unsupported context element type %v", contextElementType)
 		}
 	}
 

--- a/vendor/github.com/slack-go/slack/block_element.go
+++ b/vendor/github.com/slack-go/slack/block_element.go
@@ -9,11 +9,14 @@ const (
 	METOverflow       MessageElementType = "overflow"
 	METDatepicker     MessageElementType = "datepicker"
 	METTimepicker     MessageElementType = "timepicker"
+	METDatetimepicker MessageElementType = "datetimepicker"
 	METPlainTextInput MessageElementType = "plain_text_input"
 	METRadioButtons   MessageElementType = "radio_buttons"
+	METRichTextInput  MessageElementType = "rich_text_input"
 	METEmailTextInput MessageElementType = "email_text_input"
 	METURLTextInput   MessageElementType = "url_text_input"
 	METNumber         MessageElementType = "number_input"
+	METFileInput      MessageElementType = "file_input"
 
 	MixedElementImage MixedElementType = "mixed_image"
 	MixedElementText  MixedElementType = "mixed_text"
@@ -50,6 +53,7 @@ type Accessory struct {
 	DatePickerElement          *DatePickerBlockElement
 	TimePickerElement          *TimePickerBlockElement
 	PlainTextInputElement      *PlainTextInputBlockElement
+	RichTextInputElement       *RichTextInputBlockElement
 	RadioButtonsElement        *RadioButtonsBlockElement
 	SelectElement              *SelectBlockElement
 	MultiSelectElement         *MultiSelectBlockElement
@@ -72,6 +76,8 @@ func NewAccessory(element BlockElement) *Accessory {
 		return &Accessory{TimePickerElement: element.(*TimePickerBlockElement)}
 	case *PlainTextInputBlockElement:
 		return &Accessory{PlainTextInputElement: element.(*PlainTextInputBlockElement)}
+	case *RichTextInputBlockElement:
+		return &Accessory{RichTextInputElement: element.(*RichTextInputBlockElement)}
 	case *RadioButtonsBlockElement:
 		return &Accessory{RadioButtonsElement: element.(*RadioButtonsBlockElement)}
 	case *SelectBlockElement:
@@ -176,6 +182,12 @@ func (s *ButtonBlockElement) WithConfirm(confirm *ConfirmationBlockObject) *Butt
 	return s
 }
 
+// WithURL adds a URL for the button to link to and returns the modified ButtonBlockElement
+func (s *ButtonBlockElement) WithURL(url string) *ButtonBlockElement {
+	s.URL = url
+	return s
+}
+
 // NewButtonBlockElement returns an instance of a new button element to be used within a block
 func NewButtonBlockElement(actionID, value string, text *TextBlockObject) *ButtonBlockElement {
 	return &ButtonBlockElement{
@@ -246,6 +258,36 @@ func NewOptionsSelectBlockElement(optType string, placeholder *TextBlockObject, 
 	}
 }
 
+// WithInitialOption sets the initial option for the select element
+func (s *SelectBlockElement) WithInitialOption(option *OptionBlockObject) *SelectBlockElement {
+	s.InitialOption = option
+	return s
+}
+
+// WithInitialUser sets the initial user for the select element
+func (s *SelectBlockElement) WithInitialUser(user string) *SelectBlockElement {
+	s.InitialUser = user
+	return s
+}
+
+// WithInitialConversation sets the initial conversation for the select element
+func (s *SelectBlockElement) WithInitialConversation(conversation string) *SelectBlockElement {
+	s.InitialConversation = conversation
+	return s
+}
+
+// WithInitialChannel sets the initial channel for the select element
+func (s *SelectBlockElement) WithInitialChannel(channel string) *SelectBlockElement {
+	s.InitialChannel = channel
+	return s
+}
+
+// WithConfirm adds a confirmation dialogue to the select element
+func (s *SelectBlockElement) WithConfirm(confirm *ConfirmationBlockObject) *SelectBlockElement {
+	s.Confirm = confirm
+	return s
+}
+
 // NewOptionsGroupSelectBlockElement returns a new instance of SelectBlockElement for use with
 // the Options object only.
 func NewOptionsGroupSelectBlockElement(
@@ -297,6 +339,48 @@ func NewOptionsMultiSelectBlockElement(optType string, placeholder *TextBlockObj
 	}
 }
 
+// WithInitialOptions sets the initial options for the multi-select element
+func (s *MultiSelectBlockElement) WithInitialOptions(options ...*OptionBlockObject) *MultiSelectBlockElement {
+	s.InitialOptions = options
+	return s
+}
+
+// WithInitialUsers sets the initial users for the multi-select element
+func (s *MultiSelectBlockElement) WithInitialUsers(users ...string) *MultiSelectBlockElement {
+	s.InitialUsers = users
+	return s
+}
+
+// WithInitialConversations sets the initial conversations for the multi-select element
+func (s *MultiSelectBlockElement) WithInitialConversations(conversations ...string) *MultiSelectBlockElement {
+	s.InitialConversations = conversations
+	return s
+}
+
+// WithInitialChannels sets the initial channels for the multi-select element
+func (s *MultiSelectBlockElement) WithInitialChannels(channels ...string) *MultiSelectBlockElement {
+	s.InitialChannels = channels
+	return s
+}
+
+// WithConfirm adds a confirmation dialogue to the multi-select element
+func (s *MultiSelectBlockElement) WithConfirm(confirm *ConfirmationBlockObject) *MultiSelectBlockElement {
+	s.Confirm = confirm
+	return s
+}
+
+// WithMaxSelectedItems sets the maximum number of items that can be selected
+func (s *MultiSelectBlockElement) WithMaxSelectedItems(maxSelectedItems int) *MultiSelectBlockElement {
+	s.MaxSelectedItems = &maxSelectedItems
+	return s
+}
+
+// WithMinQueryLength sets the minimum query length for the multi-select element
+func (s *MultiSelectBlockElement) WithMinQueryLength(minQueryLength int) *MultiSelectBlockElement {
+	s.MinQueryLength = &minQueryLength
+	return s
+}
+
 // NewOptionsGroupMultiSelectBlockElement returns a new instance of MultiSelectBlockElement for use with
 // the Options object only.
 func NewOptionsGroupMultiSelectBlockElement(
@@ -338,6 +422,12 @@ func NewOverflowBlockElement(actionID string, options ...*OptionBlockObject) *Ov
 		ActionID: actionID,
 		Options:  options,
 	}
+}
+
+// WithConfirm adds a confirmation dialogue to the overflow element
+func (s *OverflowBlockElement) WithConfirm(confirm *ConfirmationBlockObject) *OverflowBlockElement {
+	s.Confirm = confirm
+	return s
 }
 
 // DatePickerBlockElement defines an element which lets users easily select a
@@ -388,6 +478,29 @@ func (s TimePickerBlockElement) ElementType() MessageElementType {
 func NewTimePickerBlockElement(actionID string) *TimePickerBlockElement {
 	return &TimePickerBlockElement{
 		Type:     METTimepicker,
+		ActionID: actionID,
+	}
+}
+
+// DateTimePickerBlockElement defines an element that allows the selection of both
+// a date and a time of day formatted as a UNIX timestamp.
+// More Information: https://api.slack.com/reference/messaging/block-elements#datetimepicker
+type DateTimePickerBlockElement struct {
+	Type            MessageElementType       `json:"type"`
+	ActionID        string                   `json:"action_id,omitempty"`
+	InitialDateTime int64                    `json:"initial_date_time,omitempty"`
+	Confirm         *ConfirmationBlockObject `json:"confirm,omitempty"`
+}
+
+// ElementType returns the type of the Element
+func (s DateTimePickerBlockElement) ElementType() MessageElementType {
+	return s.Type
+}
+
+// NewDatePickerBlockElement returns an instance of a datetime picker element
+func NewDateTimePickerBlockElement(actionID string) *DateTimePickerBlockElement {
+	return &DateTimePickerBlockElement{
+		Type:     METDatetimepicker,
 		ActionID: actionID,
 	}
 }
@@ -485,6 +598,62 @@ func NewPlainTextInputBlockElement(placeholder *TextBlockObject, actionID string
 	}
 }
 
+// WithInitialValue sets the initial value for the plain-text input element
+func (s *PlainTextInputBlockElement) WithInitialValue(initialValue string) *PlainTextInputBlockElement {
+	s.InitialValue = initialValue
+	return s
+}
+
+// WithMinLength sets the minimum length for the plain-text input element
+func (s *PlainTextInputBlockElement) WithMinLength(minLength int) *PlainTextInputBlockElement {
+	s.MinLength = minLength
+	return s
+}
+
+// WithMaxLength sets the maximum length for the plain-text input element
+func (s *PlainTextInputBlockElement) WithMaxLength(maxLength int) *PlainTextInputBlockElement {
+	s.MaxLength = maxLength
+	return s
+}
+
+// WithMultiline sets the multiline property for the plain-text input element
+func (s *PlainTextInputBlockElement) WithMultiline(multiline bool) *PlainTextInputBlockElement {
+	s.Multiline = multiline
+	return s
+}
+
+// WithDispatchActionConfig sets the dispatch action config for the plain-text input element
+func (s *PlainTextInputBlockElement) WithDispatchActionConfig(config *DispatchActionConfig) *PlainTextInputBlockElement {
+	s.DispatchActionConfig = config
+	return s
+}
+
+// RichTextInputBlockElement creates a field where allows users to enter formatted text
+// in a WYSIWYG composer, offering the same messaging writing experience as in Slack
+// More Information: https://api.slack.com/reference/block-kit/block-elements#rich_text_input
+type RichTextInputBlockElement struct {
+	Type                 MessageElementType    `json:"type"`
+	ActionID             string                `json:"action_id,omitempty"`
+	Placeholder          *TextBlockObject      `json:"placeholder,omitempty"`
+	InitialValue         *RichTextBlock        `json:"initial_value,omitempty"`
+	DispatchActionConfig *DispatchActionConfig `json:"dispatch_action_config,omitempty"`
+	FocusOnLoad          bool                  `json:"focus_on_load,omitempty"`
+}
+
+// ElementType returns the type of the Element
+func (s RichTextInputBlockElement) ElementType() MessageElementType {
+	return s.Type
+}
+
+// NewRichTextInputBlockElement returns an instance of a rich-text input element
+func NewRichTextInputBlockElement(placeholder *TextBlockObject, actionID string) *RichTextInputBlockElement {
+	return &RichTextInputBlockElement{
+		Type:        METRichTextInput,
+		ActionID:    actionID,
+		Placeholder: placeholder,
+	}
+}
+
 // CheckboxGroupsBlockElement defines an element which allows users to choose
 // one or more items from a list of possible options.
 //
@@ -566,4 +735,65 @@ func NewNumberInputBlockElement(placeholder *TextBlockObject, actionID string, i
 		Placeholder:      placeholder,
 		IsDecimalAllowed: isDecimalAllowed,
 	}
+}
+
+// WithInitialValue sets the initial value for the number input element
+func (s *NumberInputBlockElement) WithInitialValue(initialValue string) *NumberInputBlockElement {
+	s.InitialValue = initialValue
+	return s
+}
+
+// WithMinValue sets the minimum value for the number input element
+func (s *NumberInputBlockElement) WithMinValue(minValue string) *NumberInputBlockElement {
+	s.MinValue = minValue
+	return s
+}
+
+// WithMaxValue sets the maximum value for the number input element
+func (s *NumberInputBlockElement) WithMaxValue(maxValue string) *NumberInputBlockElement {
+	s.MaxValue = maxValue
+	return s
+}
+
+// WithDispatchActionConfig sets the dispatch action config for the number input element
+func (s *NumberInputBlockElement) WithDispatchActionConfig(config *DispatchActionConfig) *NumberInputBlockElement {
+	s.DispatchActionConfig = config
+	return s
+}
+
+// FileInputBlockElement creates a field where a user can upload a file.
+//
+// File input elements are currently only available in modals.
+//
+// More Information: https://api.slack.com/reference/block-kit/block-elements#file_input
+type FileInputBlockElement struct {
+	Type      MessageElementType `json:"type"`
+	ActionID  string             `json:"action_id,omitempty"`
+	FileTypes []string           `json:"filetypes,omitempty"`
+	MaxFiles  int                `json:"max_files,omitempty"`
+}
+
+// ElementType returns the type of the Element
+func (s FileInputBlockElement) ElementType() MessageElementType {
+	return s.Type
+}
+
+// NewFileInputBlockElement returns an instance of a file input element
+func NewFileInputBlockElement(actionID string) *FileInputBlockElement {
+	return &FileInputBlockElement{
+		Type:     METFileInput,
+		ActionID: actionID,
+	}
+}
+
+// WithFileTypes sets the file types that can be uploaded
+func (s *FileInputBlockElement) WithFileTypes(fileTypes ...string) *FileInputBlockElement {
+	s.FileTypes = fileTypes
+	return s
+}
+
+// WithMaxFiles sets the maximum number of files that can be uploaded
+func (s *FileInputBlockElement) WithMaxFiles(maxFiles int) *FileInputBlockElement {
+	s.MaxFiles = maxFiles
+	return s
 }

--- a/vendor/github.com/slack-go/slack/block_image.go
+++ b/vendor/github.com/slack-go/slack/block_image.go
@@ -4,11 +4,21 @@ package slack
 //
 // More Information: https://api.slack.com/reference/messaging/blocks#image
 type ImageBlock struct {
-	Type     MessageBlockType `json:"type"`
-	ImageURL string           `json:"image_url"`
-	AltText  string           `json:"alt_text"`
-	BlockID  string           `json:"block_id,omitempty"`
-	Title    *TextBlockObject `json:"title,omitempty"`
+	Type      MessageBlockType `json:"type"`
+	ImageURL  string           `json:"image_url,omitempty"`
+	AltText   string           `json:"alt_text"`
+	BlockID   string           `json:"block_id,omitempty"`
+	Title     *TextBlockObject `json:"title,omitempty"`
+	SlackFile *SlackFileObject `json:"slack_file,omitempty"`
+}
+
+// SlackFileObject Defines an object containing Slack file information to be used in an
+// image block or image element.
+//
+// More Information: https://api.slack.com/reference/block-kit/composition-objects#slack_file
+type SlackFileObject struct {
+	ID  string `json:"id,omitempty"`
+	URL string `json:"url,omitempty"`
 }
 
 // BlockType returns the type of the block

--- a/vendor/github.com/slack-go/slack/block_input.go
+++ b/vendor/github.com/slack-go/slack/block_input.go
@@ -28,3 +28,15 @@ func NewInputBlock(blockID string, label, hint *TextBlockObject, element BlockEl
 		Hint:    hint,
 	}
 }
+
+// WithOptional sets the optional flag on the input block
+func (s *InputBlock) WithOptional(optional bool) *InputBlock {
+	s.Optional = optional
+	return s
+}
+
+// WithDispatchAction sets the dispatch action flag on the input block
+func (s *InputBlock) WithDispatchAction(dispatchAction bool) *InputBlock {
+	s.DispatchAction = dispatchAction
+	return s
+}

--- a/vendor/github.com/slack-go/slack/block_object.go
+++ b/vendor/github.com/slack-go/slack/block_object.go
@@ -147,6 +147,16 @@ func (s TextBlockObject) Validate() error {
 		return errors.New("emoji cannot be true in mrkdown")
 	}
 
+	// https://api.slack.com/reference/block-kit/composition-objects#text__fields
+	if len(s.Text) == 0 {
+		return errors.New("text must have a minimum length of 1")
+	}
+
+	// https://api.slack.com/reference/block-kit/composition-objects#text__fields
+	if len(s.Text) > 3000 {
+		return errors.New("text cannot be longer than 3000 characters")
+	}
+
 	return nil
 }
 
@@ -177,7 +187,7 @@ type ConfirmationBlockObject struct {
 	Title   *TextBlockObject `json:"title"`
 	Text    *TextBlockObject `json:"text"`
 	Confirm *TextBlockObject `json:"confirm"`
-	Deny    *TextBlockObject `json:"deny"`
+	Deny    *TextBlockObject `json:"deny,omitempty"`
 	Style   Style            `json:"style,omitempty"`
 }
 

--- a/vendor/github.com/slack-go/slack/block_rich_text.go
+++ b/vendor/github.com/slack-go/slack/block_rich_text.go
@@ -40,6 +40,12 @@ func (e *RichTextBlock) UnmarshalJSON(b []byte) error {
 		switch s.Type {
 		case RTESection:
 			elem = &RichTextSection{}
+		case RTEList:
+			elem = &RichTextList{}
+		case RTEQuote:
+			elem = &RichTextQuote{}
+		case RTEPreformatted:
+			elem = &RichTextPreformatted{}
 		default:
 			elems = append(elems, &RichTextUnknown{
 				Type: s.Type,
@@ -92,12 +98,92 @@ func (u RichTextUnknown) RichTextElementType() RichTextElementType {
 	return u.Type
 }
 
+type RichTextListElementType string
+
+const (
+	RTEListOrdered RichTextListElementType = "ordered"
+	RTEListBullet  RichTextListElementType = "bullet"
+)
+
+type RichTextList struct {
+	Type     RichTextElementType     `json:"type"`
+	Elements []RichTextElement       `json:"elements"`
+	Style    RichTextListElementType `json:"style"`
+	Indent   int                     `json:"indent"`
+}
+
+// NewRichTextList returns a new rich text list element.
+func NewRichTextList(style RichTextListElementType, indent int, elements ...RichTextElement) *RichTextList {
+	return &RichTextList{
+		Type:     RTEList,
+		Elements: elements,
+		Style:    style,
+		Indent:   indent,
+	}
+}
+
+// ElementType returns the type of the Element
+func (s RichTextList) RichTextElementType() RichTextElementType {
+	return s.Type
+}
+
+func (e *RichTextList) UnmarshalJSON(b []byte) error {
+	var raw struct {
+		RawElements []json.RawMessage       `json:"elements"`
+		Style       RichTextListElementType `json:"style"`
+		Indent      int                     `json:"indent"`
+	}
+	if string(b) == "{}" {
+		return nil
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	elems := make([]RichTextElement, 0, len(raw.RawElements))
+	for _, r := range raw.RawElements {
+		var s struct {
+			Type RichTextElementType `json:"type"`
+		}
+		if err := json.Unmarshal(r, &s); err != nil {
+			return err
+		}
+		var elem RichTextElement
+		switch s.Type {
+		case RTESection:
+			elem = &RichTextSection{}
+		case RTEList:
+			elem = &RichTextList{}
+		case RTEQuote:
+			elem = &RichTextQuote{}
+		case RTEPreformatted:
+			elem = &RichTextPreformatted{}
+		default:
+			elems = append(elems, &RichTextUnknown{
+				Type: s.Type,
+				Raw:  string(r),
+			})
+			continue
+		}
+		if err := json.Unmarshal(r, elem); err != nil {
+			return err
+		}
+		elems = append(elems, elem)
+	}
+	*e = RichTextList{
+		Type:     RTEList,
+		Elements: elems,
+		Style:    raw.Style,
+		Indent:   raw.Indent,
+	}
+	return nil
+}
+
 type RichTextSection struct {
 	Type     RichTextElementType      `json:"type"`
 	Elements []RichTextSectionElement `json:"elements"`
 }
 
-// ElementType returns the type of the Element
+// RichTextElementType returns the type of the Element
 func (s RichTextSection) RichTextElementType() RichTextElementType {
 	return s.Type
 }
@@ -255,6 +341,7 @@ type RichTextSectionEmojiElement struct {
 	Type     RichTextSectionElementType `json:"type"`
 	Name     string                     `json:"name"`
 	SkinTone int                        `json:"skin_tone"`
+	Unicode  string                     `json:"unicode,omitempty"`
 	Style    *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
@@ -294,7 +381,7 @@ func NewRichTextSectionLinkElement(url, text string, style *RichTextSectionTextS
 type RichTextSectionTeamElement struct {
 	Type   RichTextSectionElementType `json:"type"`
 	TeamID string                     `json:"team_id"`
-	Style  *RichTextSectionTextStyle  `json:"style.omitempty"`
+	Style  *RichTextSectionTextStyle  `json:"style,omitempty"`
 }
 
 func (r RichTextSectionTeamElement) RichTextSectionElementType() RichTextSectionElementType {
@@ -328,16 +415,22 @@ func NewRichTextSectionUserGroupElement(usergroupID string) *RichTextSectionUser
 type RichTextSectionDateElement struct {
 	Type      RichTextSectionElementType `json:"type"`
 	Timestamp JSONTime                   `json:"timestamp"`
+	Format    string                     `json:"format"`
+	URL       *string                    `json:"url,omitempty"`
+	Fallback  *string                    `json:"fallback,omitempty"`
 }
 
 func (r RichTextSectionDateElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
 }
 
-func NewRichTextSectionDateElement(timestamp int64) *RichTextSectionDateElement {
+func NewRichTextSectionDateElement(timestamp int64, format string, url *string, fallback *string) *RichTextSectionDateElement {
 	return &RichTextSectionDateElement{
 		Type:      RTSEDate,
 		Timestamp: JSONTime(timestamp),
+		Format:    format,
+		URL:       url,
+		Fallback:  fallback,
 	}
 }
 
@@ -380,4 +473,63 @@ type RichTextSectionUnknownElement struct {
 
 func (r RichTextSectionUnknownElement) RichTextSectionElementType() RichTextSectionElementType {
 	return r.Type
+}
+
+// RichTextQuote represents rich_text_quote element type.
+type RichTextQuote RichTextSection
+
+// RichTextElementType returns the type of the Element
+func (s *RichTextQuote) RichTextElementType() RichTextElementType {
+	return s.Type
+}
+
+func (s *RichTextQuote) UnmarshalJSON(b []byte) error {
+	// reusing the RichTextSection struct, as it's the same as RichTextQuote.
+	var rts RichTextSection
+	if err := json.Unmarshal(b, &rts); err != nil {
+		return err
+	}
+	*s = RichTextQuote(rts)
+	s.Type = RTEQuote
+	return nil
+}
+
+// RichTextPreformatted represents rich_text_quote element type.
+type RichTextPreformatted struct {
+	RichTextSection
+	Border int `json:"border"`
+}
+
+// RichTextElementType returns the type of the Element
+func (s *RichTextPreformatted) RichTextElementType() RichTextElementType {
+	return s.Type
+}
+
+func (s *RichTextPreformatted) UnmarshalJSON(b []byte) error {
+	var rts RichTextSection
+	if err := json.Unmarshal(b, &rts); err != nil {
+		return err
+	}
+	// we define standalone fields because we need to unmarshal the border
+	// field.  We can not directly unmarshal the data into
+	// RichTextPreformatted because it will cause an infinite loop.  We also
+	// can not define a struct with embedded RichTextSection and Border fields
+	// because the json package will not unmarshal the data into the
+	// standalone fields, once it sees UnmarshalJSON method on the embedded
+	// struct.  The drawback is that we have to process the data twice, and
+	// have to define a standalone struct with the same set of fields as the
+	// original struct, which may become a maintenance burden (i.e. update the
+	// fields in two places, should it ever change).
+	var standalone struct {
+		Border int `json:"border"`
+	}
+	if err := json.Unmarshal(b, &standalone); err != nil {
+		return err
+	}
+	*s = RichTextPreformatted{
+		RichTextSection: rts,
+		Border:          standalone.Border,
+	}
+	s.Type = RTEPreformatted
+	return nil
 }

--- a/vendor/github.com/slack-go/slack/block_video.go
+++ b/vendor/github.com/slack-go/slack/block_video.go
@@ -1,0 +1,65 @@
+package slack
+
+// VideoBlock defines data required to display a video as a block element
+//
+// More Information: https://api.slack.com/reference/block-kit/blocks#video
+type VideoBlock struct {
+	Type            MessageBlockType `json:"type"`
+	VideoURL        string           `json:"video_url"`
+	ThumbnailURL    string           `json:"thumbnail_url"`
+	AltText         string           `json:"alt_text"`
+	Title           *TextBlockObject `json:"title"`
+	BlockID         string           `json:"block_id,omitempty"`
+	TitleURL        string           `json:"title_url,omitempty"`
+	AuthorName      string           `json:"author_name,omitempty"`
+	ProviderName    string           `json:"provider_name,omitempty"`
+	ProviderIconURL string           `json:"provider_icon_url,omitempty"`
+	Description     *TextBlockObject `json:"description,omitempty"`
+}
+
+// BlockType returns the type of the block
+func (s VideoBlock) BlockType() MessageBlockType {
+	return s.Type
+}
+
+// NewVideoBlock returns an instance of a new Video Block type
+func NewVideoBlock(videoURL, thumbnailURL, altText, blockID string, title *TextBlockObject) *VideoBlock {
+	return &VideoBlock{
+		Type:         MBTVideo,
+		VideoURL:     videoURL,
+		ThumbnailURL: thumbnailURL,
+		AltText:      altText,
+		BlockID:      blockID,
+		Title:        title,
+	}
+}
+
+// WithAuthorName sets the author name for the VideoBlock
+func (s *VideoBlock) WithAuthorName(authorName string) *VideoBlock {
+	s.AuthorName = authorName
+	return s
+}
+
+// WithTitleURL sets the title URL for the VideoBlock
+func (s *VideoBlock) WithTitleURL(titleURL string) *VideoBlock {
+	s.TitleURL = titleURL
+	return s
+}
+
+// WithDescription sets the description for the VideoBlock
+func (s *VideoBlock) WithDescription(description *TextBlockObject) *VideoBlock {
+	s.Description = description
+	return s
+}
+
+// WithProviderIconURL sets the provider icon URL for the VideoBlock
+func (s *VideoBlock) WithProviderIconURL(providerIconURL string) *VideoBlock {
+	s.ProviderIconURL = providerIconURL
+	return s
+}
+
+// WithProviderName sets the provider name for the VideoBlock
+func (s *VideoBlock) WithProviderName(providerName string) *VideoBlock {
+	s.ProviderName = providerName
+	return s
+}

--- a/vendor/github.com/slack-go/slack/bookmarks.go
+++ b/vendor/github.com/slack-go/slack/bookmarks.go
@@ -55,12 +55,14 @@ type listBookmarksResponse struct {
 	SlackResponse
 }
 
-// AddBookmark adds a bookmark in a channel
+// AddBookmark adds a bookmark in a channel.
+// For more details, see AddBookmarkContext documentation.
 func (api *Client) AddBookmark(channelID string, params AddBookmarkParameters) (Bookmark, error) {
 	return api.AddBookmarkContext(context.Background(), channelID, params)
 }
 
-// AddBookmarkContext adds a bookmark in a channel with a custom context
+// AddBookmarkContext adds a bookmark in a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/bookmarks.add
 func (api *Client) AddBookmarkContext(ctx context.Context, channelID string, params AddBookmarkParameters) (Bookmark, error) {
 	values := url.Values{
 		"channel_id": {channelID},
@@ -89,12 +91,14 @@ func (api *Client) AddBookmarkContext(ctx context.Context, channelID string, par
 	return response.Bookmark, response.Err()
 }
 
-// RemoveBookmark removes a bookmark from a channel
+// RemoveBookmark removes a bookmark from a channel.
+// For more details, see RemoveBookmarkContext documentation.
 func (api *Client) RemoveBookmark(channelID, bookmarkID string) error {
 	return api.RemoveBookmarkContext(context.Background(), channelID, bookmarkID)
 }
 
-// RemoveBookmarkContext removes a bookmark from a channel with a custom context
+// RemoveBookmarkContext removes a bookmark from a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/bookmarks.remove
 func (api *Client) RemoveBookmarkContext(ctx context.Context, channelID, bookmarkID string) error {
 	values := url.Values{
 		"channel_id":  {channelID},
@@ -111,11 +115,13 @@ func (api *Client) RemoveBookmarkContext(ctx context.Context, channelID, bookmar
 }
 
 // ListBookmarks returns all bookmarks for a channel.
+// For more details, see ListBookmarksContext documentation.
 func (api *Client) ListBookmarks(channelID string) ([]Bookmark, error) {
 	return api.ListBookmarksContext(context.Background(), channelID)
 }
 
 // ListBookmarksContext returns all bookmarks for a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/bookmarks.edit
 func (api *Client) ListBookmarksContext(ctx context.Context, channelID string) ([]Bookmark, error) {
 	values := url.Values{
 		"channel_id": {channelID},
@@ -130,10 +136,14 @@ func (api *Client) ListBookmarksContext(ctx context.Context, channelID string) (
 	return response.Bookmarks, response.Err()
 }
 
+// EditBookmark edits a bookmark in a channel.
+// For more details, see EditBookmarkContext documentation.
 func (api *Client) EditBookmark(channelID, bookmarkID string, params EditBookmarkParameters) (Bookmark, error) {
 	return api.EditBookmarkContext(context.Background(), channelID, bookmarkID, params)
 }
 
+// EditBookmarkContext edits a bookmark in a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/bookmarks.edit
 func (api *Client) EditBookmarkContext(ctx context.Context, channelID, bookmarkID string, params EditBookmarkParameters) (Bookmark, error) {
 	values := url.Values{
 		"channel_id":  {channelID},

--- a/vendor/github.com/slack-go/slack/bots.go
+++ b/vendor/github.com/slack-go/slack/bots.go
@@ -35,19 +35,30 @@ func (api *Client) botRequest(ctx context.Context, path string, values url.Value
 	return response, nil
 }
 
-// GetBotInfo will retrieve the complete bot information
-func (api *Client) GetBotInfo(bot string) (*Bot, error) {
-	return api.GetBotInfoContext(context.Background(), bot)
+type GetBotInfoParameters struct {
+	Bot    string
+	TeamID string
 }
 
-// GetBotInfoContext will retrieve the complete bot information using a custom context
-func (api *Client) GetBotInfoContext(ctx context.Context, bot string) (*Bot, error) {
+// GetBotInfo will retrieve the complete bot information.
+// For more details, see GetBotInfoContext documentation.
+func (api *Client) GetBotInfo(parameters GetBotInfoParameters) (*Bot, error) {
+	return api.GetBotInfoContext(context.Background(), parameters)
+}
+
+// GetBotInfoContext will retrieve the complete bot information using a custom context.
+// Slack API docs: https://api.slack.com/methods/bots.info
+func (api *Client) GetBotInfoContext(ctx context.Context, parameters GetBotInfoParameters) (*Bot, error) {
 	values := url.Values{
 		"token": {api.token},
 	}
 
-	if bot != "" {
-		values.Add("bot", bot)
+	if parameters.Bot != "" {
+		values.Add("bot", parameters.Bot)
+	}
+
+	if parameters.TeamID != "" {
+		values.Add("team_id", parameters.TeamID)
 	}
 
 	response, err := api.botRequest(ctx, "bots.info", values)

--- a/vendor/github.com/slack-go/slack/calls.go
+++ b/vendor/github.com/slack-go/slack/calls.go
@@ -1,0 +1,216 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+type Call struct {
+	ID                string            `json:"id"`
+	Title             string            `json:"title"`
+	DateStart         JSONTime          `json:"date_start"`
+	DateEnd           JSONTime          `json:"date_end"`
+	ExternalUniqueID  string            `json:"external_unique_id"`
+	JoinURL           string            `json:"join_url"`
+	DesktopAppJoinURL string            `json:"desktop_app_join_url"`
+	ExternalDisplayID string            `json:"external_display_id"`
+	Participants      []CallParticipant `json:"users"`
+	Channels          []string          `json:"channels"`
+}
+
+// CallParticipant is a thin user representation which has a SlackID, ExternalID, or both.
+//
+// See: https://api.slack.com/apis/calls#users
+type CallParticipant struct {
+	SlackID     string `json:"slack_id,omitempty"`
+	ExternalID  string `json:"external_id,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	AvatarURL   string `json:"avatar_url,omitempty"`
+}
+
+// Valid checks if the CallUser has a is valid with a SlackID or ExternalID or both.
+func (u CallParticipant) Valid() bool {
+	return u.SlackID != "" || u.ExternalID != ""
+}
+
+type AddCallParameters struct {
+	JoinURL           string // Required
+	ExternalUniqueID  string // Required
+	CreatedBy         string // Required if using a bot token
+	Title             string
+	DesktopAppJoinURL string
+	ExternalDisplayID string
+	DateStart         JSONTime
+	Participants      []CallParticipant
+}
+
+type UpdateCallParameters struct {
+	Title             string
+	DesktopAppJoinURL string
+	JoinURL           string
+}
+
+type EndCallParameters struct {
+	// Duration is the duration of the call in seconds. Omitted if 0.
+	Duration time.Duration
+}
+
+type callResponse struct {
+	Call Call `json:"call"`
+	SlackResponse
+}
+
+// AddCall adds a new Call to the Slack API.
+func (api *Client) AddCall(params AddCallParameters) (Call, error) {
+	return api.AddCallContext(context.Background(), params)
+}
+
+// AddCallContext adds a new Call to the Slack API.
+func (api *Client) AddCallContext(ctx context.Context, params AddCallParameters) (Call, error) {
+	values := url.Values{
+		"token":              {api.token},
+		"join_url":           {params.JoinURL},
+		"external_unique_id": {params.ExternalUniqueID},
+	}
+	if params.CreatedBy != "" {
+		values.Set("created_by", params.CreatedBy)
+	}
+	if params.DateStart != 0 {
+		values.Set("date_start", strconv.FormatInt(int64(params.DateStart), 10))
+	}
+	if params.DesktopAppJoinURL != "" {
+		values.Set("desktop_app_join_url", params.DesktopAppJoinURL)
+	}
+	if params.ExternalDisplayID != "" {
+		values.Set("external_display_id", params.ExternalDisplayID)
+	}
+	if params.Title != "" {
+		values.Set("title", params.Title)
+	}
+	if len(params.Participants) > 0 {
+		data, err := json.Marshal(params.Participants)
+		if err != nil {
+			return Call{}, err
+		}
+		values.Set("users", string(data))
+	}
+
+	response := &callResponse{}
+	if err := api.postMethod(ctx, "calls.add", values, response); err != nil {
+		return Call{}, err
+	}
+
+	return response.Call, response.Err()
+}
+
+// GetCallInfo returns information about a Call.
+func (api *Client) GetCall(callID string) (Call, error) {
+	return api.GetCallContext(context.Background(), callID)
+}
+
+// GetCallInfoContext returns information about a Call.
+func (api *Client) GetCallContext(ctx context.Context, callID string) (Call, error) {
+	values := url.Values{
+		"token": {api.token},
+		"id":    {callID},
+	}
+
+	response := &callResponse{}
+	if err := api.postMethod(ctx, "calls.info", values, response); err != nil {
+		return Call{}, err
+	}
+	return response.Call, response.Err()
+}
+
+func (api *Client) UpdateCall(callID string, params UpdateCallParameters) (Call, error) {
+	return api.UpdateCallContext(context.Background(), callID, params)
+}
+
+// UpdateCallContext updates a Call with the given parameters.
+func (api *Client) UpdateCallContext(ctx context.Context, callID string, params UpdateCallParameters) (Call, error) {
+	values := url.Values{
+		"token": {api.token},
+		"id":    {callID},
+	}
+
+	if params.DesktopAppJoinURL != "" {
+		values.Set("desktop_app_join_url", params.DesktopAppJoinURL)
+	}
+	if params.JoinURL != "" {
+		values.Set("join_url", params.JoinURL)
+	}
+	if params.Title != "" {
+		values.Set("title", params.Title)
+	}
+
+	response := &callResponse{}
+	if err := api.postMethod(ctx, "calls.update", values, response); err != nil {
+		return Call{}, err
+	}
+	return response.Call, response.Err()
+}
+
+// EndCall ends a Call.
+func (api *Client) EndCall(callID string, params EndCallParameters) error {
+	return api.EndCallContext(context.Background(), callID, params)
+}
+
+// EndCallContext ends a Call.
+func (api *Client) EndCallContext(ctx context.Context, callID string, params EndCallParameters) error {
+	values := url.Values{
+		"token": {api.token},
+		"id":    {callID},
+	}
+
+	if params.Duration != 0 {
+		values.Set("duration", strconv.FormatInt(int64(params.Duration.Seconds()), 10))
+	}
+
+	response := &SlackResponse{}
+	if err := api.postMethod(ctx, "calls.end", values, response); err != nil {
+		return err
+	}
+	return response.Err()
+}
+
+// CallAddParticipants adds users to a Call.
+func (api *Client) CallAddParticipants(callID string, participants []CallParticipant) error {
+	return api.CallAddParticipantsContext(context.Background(), callID, participants)
+}
+
+// CallAddParticipantsContext adds users to a Call.
+func (api *Client) CallAddParticipantsContext(ctx context.Context, callID string, participants []CallParticipant) error {
+	return api.setCallParticipants(ctx, "calls.participants.add", callID, participants)
+}
+
+// CallRemoveParticipants removes users from a Call.
+func (api *Client) CallRemoveParticipants(callID string, participants []CallParticipant) error {
+	return api.CallRemoveParticipantsContext(context.Background(), callID, participants)
+}
+
+// CallRemoveParticipantsContext removes users from a Call.
+func (api *Client) CallRemoveParticipantsContext(ctx context.Context, callID string, participants []CallParticipant) error {
+	return api.setCallParticipants(ctx, "calls.participants.remove", callID, participants)
+}
+
+func (api *Client) setCallParticipants(ctx context.Context, method, callID string, participants []CallParticipant) error {
+	values := url.Values{
+		"token": {api.token},
+		"id":    {callID},
+	}
+
+	data, err := json.Marshal(participants)
+	if err != nil {
+		return err
+	}
+	values.Set("users", string(data))
+
+	response := &SlackResponse{}
+	if err := api.postMethod(ctx, method, values, response); err != nil {
+		return err
+	}
+	return response.Err()
+}

--- a/vendor/github.com/slack-go/slack/canvas.go
+++ b/vendor/github.com/slack-go/slack/canvas.go
@@ -1,0 +1,264 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+)
+
+type CanvasDetails struct {
+	CanvasID string `json:"canvas_id"`
+}
+
+type DocumentContent struct {
+	Type     string `json:"type"`
+	Markdown string `json:"markdown,omitempty"`
+}
+
+type CanvasChange struct {
+	Operation       string          `json:"operation"`
+	SectionID       string          `json:"section_id,omitempty"`
+	DocumentContent DocumentContent `json:"document_content"`
+}
+
+type EditCanvasParams struct {
+	CanvasID string         `json:"canvas_id"`
+	Changes  []CanvasChange `json:"changes"`
+}
+
+type SetCanvasAccessParams struct {
+	CanvasID    string   `json:"canvas_id"`
+	AccessLevel string   `json:"access_level"`
+	ChannelIDs  []string `json:"channel_ids,omitempty"`
+	UserIDs     []string `json:"user_ids,omitempty"`
+}
+
+type DeleteCanvasAccessParams struct {
+	CanvasID   string   `json:"canvas_id"`
+	ChannelIDs []string `json:"channel_ids,omitempty"`
+	UserIDs    []string `json:"user_ids,omitempty"`
+}
+
+type LookupCanvasSectionsCriteria struct {
+	SectionTypes []string `json:"section_types,omitempty"`
+	ContainsText string   `json:"contains_text,omitempty"`
+}
+
+type LookupCanvasSectionsParams struct {
+	CanvasID string                       `json:"canvas_id"`
+	Criteria LookupCanvasSectionsCriteria `json:"criteria"`
+}
+
+type CanvasSection struct {
+	ID string `json:"id"`
+}
+
+type LookupCanvasSectionsResponse struct {
+	SlackResponse
+	Sections []CanvasSection `json:"sections"`
+}
+
+// CreateCanvas creates a new canvas.
+// For more details, see CreateCanvasContext documentation.
+func (api *Client) CreateCanvas(title string, documentContent DocumentContent) (string, error) {
+	return api.CreateCanvasContext(context.Background(), title, documentContent)
+}
+
+// CreateCanvasContext creates a new canvas with a custom context.
+// Slack API docs: https://api.slack.com/methods/canvases.create
+func (api *Client) CreateCanvasContext(ctx context.Context, title string, documentContent DocumentContent) (string, error) {
+	values := url.Values{
+		"token": {api.token},
+	}
+	if title != "" {
+		values.Add("title", title)
+	}
+	if documentContent.Type != "" {
+		documentContentJSON, err := json.Marshal(documentContent)
+		if err != nil {
+			return "", err
+		}
+		values.Add("document_content", string(documentContentJSON))
+	}
+
+	response := struct {
+		SlackResponse
+		CanvasID string `json:"canvas_id"`
+	}{}
+
+	err := api.postMethod(ctx, "canvases.create", values, &response)
+	if err != nil {
+		return "", err
+	}
+
+	return response.CanvasID, response.Err()
+}
+
+// DeleteCanvas deletes an existing canvas.
+// For more details, see DeleteCanvasContext documentation.
+func (api *Client) DeleteCanvas(canvasID string) error {
+	return api.DeleteCanvasContext(context.Background(), canvasID)
+}
+
+// DeleteCanvasContext deletes an existing canvas with a custom context.
+// Slack API docs: https://api.slack.com/methods/canvases.delete
+func (api *Client) DeleteCanvasContext(ctx context.Context, canvasID string) error {
+	values := url.Values{
+		"token":     {api.token},
+		"canvas_id": {canvasID},
+	}
+
+	response := struct {
+		SlackResponse
+	}{}
+
+	err := api.postMethod(ctx, "canvases.delete", values, &response)
+	if err != nil {
+		return err
+	}
+
+	return response.Err()
+}
+
+// EditCanvas edits an existing canvas.
+// For more details, see EditCanvasContext documentation.
+func (api *Client) EditCanvas(params EditCanvasParams) error {
+	return api.EditCanvasContext(context.Background(), params)
+}
+
+// EditCanvasContext edits an existing canvas with a custom context.
+// Slack API docs: https://api.slack.com/methods/canvases.edit
+func (api *Client) EditCanvasContext(ctx context.Context, params EditCanvasParams) error {
+	values := url.Values{
+		"token":     {api.token},
+		"canvas_id": {params.CanvasID},
+	}
+
+	changesJSON, err := json.Marshal(params.Changes)
+	if err != nil {
+		return err
+	}
+	values.Add("changes", string(changesJSON))
+
+	response := struct {
+		SlackResponse
+	}{}
+
+	err = api.postMethod(ctx, "canvases.edit", values, &response)
+	if err != nil {
+		return err
+	}
+
+	return response.Err()
+}
+
+// SetCanvasAccess sets the access level to a canvas for specified entities.
+// For more details, see SetCanvasAccessContext documentation.
+func (api *Client) SetCanvasAccess(params SetCanvasAccessParams) error {
+	return api.SetCanvasAccessContext(context.Background(), params)
+}
+
+// SetCanvasAccessContext sets the access level to a canvas for specified entities with a custom context.
+// Slack API docs: https://api.slack.com/methods/canvases.access.set
+func (api *Client) SetCanvasAccessContext(ctx context.Context, params SetCanvasAccessParams) error {
+	values := url.Values{
+		"token":        {api.token},
+		"canvas_id":    {params.CanvasID},
+		"access_level": {params.AccessLevel},
+	}
+	if len(params.ChannelIDs) > 0 {
+		channelIDsJSON, err := json.Marshal(params.ChannelIDs)
+		if err != nil {
+			return err
+		}
+		values.Add("channel_ids", string(channelIDsJSON))
+	}
+	if len(params.UserIDs) > 0 {
+		userIDsJSON, err := json.Marshal(params.UserIDs)
+		if err != nil {
+			return err
+		}
+		values.Add("user_ids", string(userIDsJSON))
+	}
+
+	response := struct {
+		SlackResponse
+	}{}
+
+	err := api.postMethod(ctx, "canvases.access.set", values, &response)
+	if err != nil {
+		return err
+	}
+
+	return response.Err()
+}
+
+// DeleteCanvasAccess removes access to a canvas for specified entities.
+// For more details, see DeleteCanvasAccessContext documentation.
+func (api *Client) DeleteCanvasAccess(params DeleteCanvasAccessParams) error {
+	return api.DeleteCanvasAccessContext(context.Background(), params)
+}
+
+// DeleteCanvasAccessContext removes access to a canvas for specified entities with a custom context.
+// Slack API docs: https://api.slack.com/methods/canvases.access.delete
+func (api *Client) DeleteCanvasAccessContext(ctx context.Context, params DeleteCanvasAccessParams) error {
+	values := url.Values{
+		"token":     {api.token},
+		"canvas_id": {params.CanvasID},
+	}
+	if len(params.ChannelIDs) > 0 {
+		channelIDsJSON, err := json.Marshal(params.ChannelIDs)
+		if err != nil {
+			return err
+		}
+		values.Add("channel_ids", string(channelIDsJSON))
+	}
+	if len(params.UserIDs) > 0 {
+		userIDsJSON, err := json.Marshal(params.UserIDs)
+		if err != nil {
+			return err
+		}
+		values.Add("user_ids", string(userIDsJSON))
+	}
+
+	response := struct {
+		SlackResponse
+	}{}
+
+	err := api.postMethod(ctx, "canvases.access.delete", values, &response)
+	if err != nil {
+		return err
+	}
+
+	return response.Err()
+}
+
+// LookupCanvasSections finds sections matching the provided criteria.
+// For more details, see LookupCanvasSectionsContext documentation.
+func (api *Client) LookupCanvasSections(params LookupCanvasSectionsParams) ([]CanvasSection, error) {
+	return api.LookupCanvasSectionsContext(context.Background(), params)
+}
+
+// LookupCanvasSectionsContext finds sections matching the provided criteria with a custom context.
+// Slack API docs: https://api.slack.com/methods/canvases.sections.lookup
+func (api *Client) LookupCanvasSectionsContext(ctx context.Context, params LookupCanvasSectionsParams) ([]CanvasSection, error) {
+	values := url.Values{
+		"token":     {api.token},
+		"canvas_id": {params.CanvasID},
+	}
+
+	criteriaJSON, err := json.Marshal(params.Criteria)
+	if err != nil {
+		return nil, err
+	}
+	values.Add("criteria", string(criteriaJSON))
+
+	response := LookupCanvasSectionsResponse{}
+
+	err = api.postMethod(ctx, "canvases.sections.lookup", values, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Sections, response.Err()
+}

--- a/vendor/github.com/slack-go/slack/channels.go
+++ b/vendor/github.com/slack-go/slack/channels.go
@@ -19,10 +19,11 @@ type channelResponseFull struct {
 // Channel contains information about the channel
 type Channel struct {
 	GroupConversation
-	IsChannel bool   `json:"is_channel"`
-	IsGeneral bool   `json:"is_general"`
-	IsMember  bool   `json:"is_member"`
-	Locale    string `json:"locale"`
+	IsChannel  bool        `json:"is_channel"`
+	IsGeneral  bool        `json:"is_general"`
+	IsMember   bool        `json:"is_member"`
+	Locale     string      `json:"locale"`
+	Properties *Properties `json:"properties"`
 }
 
 func (api *Client) channelRequest(ctx context.Context, path string, values url.Values) (*channelResponseFull, error) {

--- a/vendor/github.com/slack-go/slack/chat.go
+++ b/vendor/github.com/slack-go/slack/chat.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 
 	"github.com/slack-go/slack/slackutilsx"
@@ -29,14 +30,14 @@ const (
 
 type chatResponseFull struct {
 	Channel            string `json:"channel"`
-	Timestamp          string `json:"ts"`                             //Regular message timestamp
-	MessageTimeStamp   string `json:"message_ts"`                     //Ephemeral message timestamp
-	ScheduledMessageID string `json:"scheduled_message_id,omitempty"` //Scheduled message id
+	Timestamp          string `json:"ts"`                             // Regular message timestamp
+	MessageTimeStamp   string `json:"message_ts"`                     // Ephemeral message timestamp
+	ScheduledMessageID string `json:"scheduled_message_id,omitempty"` // Scheduled message id
 	Text               string `json:"text"`
 	SlackResponse
 }
 
-// getMessageTimestamp will inspect the `chatResponseFull` to ruturn a timestamp value
+// getMessageTimestamp will inspect the `chatResponseFull` to return a timestamp value
 // in `chat.postMessage` its under `ts`
 // in `chat.postEphemeral` its under `message_ts`
 func (c chatResponseFull) getMessageTimestamp() string {
@@ -87,12 +88,14 @@ func NewPostMessageParameters() PostMessageParameters {
 	}
 }
 
-// DeleteMessage deletes a message in a channel
+// DeleteMessage deletes a message in a channel.
+// For more details, see DeleteMessageContext documentation.
 func (api *Client) DeleteMessage(channel, messageTimestamp string) (string, string, error) {
 	return api.DeleteMessageContext(context.Background(), channel, messageTimestamp)
 }
 
-// DeleteMessageContext deletes a message in a channel with a custom context
+// DeleteMessageContext deletes a message in a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.delete
 func (api *Client) DeleteMessageContext(ctx context.Context, channel, messageTimestamp string) (string, string, error) {
 	respChannel, respTimestamp, _, err := api.SendMessageContext(
 		ctx,
@@ -105,13 +108,13 @@ func (api *Client) DeleteMessageContext(ctx context.Context, channel, messageTim
 // ScheduleMessage sends a message to a channel.
 // Message is escaped by default according to https://api.slack.com/docs/formatting
 // Use http://davestevens.github.io/slack-message-builder/ to help crafting your message.
+// For more details, see ScheduleMessageContext documentation.
 func (api *Client) ScheduleMessage(channelID, postAt string, options ...MsgOption) (string, string, error) {
 	return api.ScheduleMessageContext(context.Background(), channelID, postAt, options...)
 }
 
-// ScheduleMessageContext sends a message to a channel with a custom context
-//
-// For more details, see ScheduleMessage documentation.
+// ScheduleMessageContext sends a message to a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.scheduleMessage
 func (api *Client) ScheduleMessageContext(ctx context.Context, channelID, postAt string, options ...MsgOption) (string, string, error) {
 	respChannel, respTimestamp, _, err := api.SendMessageContext(
 		ctx,
@@ -125,12 +128,13 @@ func (api *Client) ScheduleMessageContext(ctx context.Context, channelID, postAt
 // PostMessage sends a message to a channel.
 // Message is escaped by default according to https://api.slack.com/docs/formatting
 // Use http://davestevens.github.io/slack-message-builder/ to help crafting your message.
+// For more details, see PostMessageContext documentation.
 func (api *Client) PostMessage(channelID string, options ...MsgOption) (string, string, error) {
 	return api.PostMessageContext(context.Background(), channelID, options...)
 }
 
-// PostMessageContext sends a message to a channel with a custom context
-// For more details, see PostMessage documentation.
+// PostMessageContext sends a message to a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.postMessage
 func (api *Client) PostMessageContext(ctx context.Context, channelID string, options ...MsgOption) (string, string, error) {
 	respChannel, respTimestamp, _, err := api.SendMessageContext(
 		ctx,
@@ -144,12 +148,13 @@ func (api *Client) PostMessageContext(ctx context.Context, channelID string, opt
 // PostEphemeral sends an ephemeral message to a user in a channel.
 // Message is escaped by default according to https://api.slack.com/docs/formatting
 // Use http://davestevens.github.io/slack-message-builder/ to help crafting your message.
+// For more details, see PostEphemeralContext documentation.
 func (api *Client) PostEphemeral(channelID, userID string, options ...MsgOption) (string, error) {
 	return api.PostEphemeralContext(context.Background(), channelID, userID, options...)
 }
 
-// PostEphemeralContext sends an ephemeal message to a user in a channel with a custom context
-// For more details, see PostEphemeral documentation
+// PostEphemeralContext sends an ephemeral message to a user in a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.postEphemeral
 func (api *Client) PostEphemeralContext(ctx context.Context, channelID, userID string, options ...MsgOption) (timestamp string, err error) {
 	_, timestamp, _, err = api.SendMessageContext(
 		ctx,
@@ -160,12 +165,14 @@ func (api *Client) PostEphemeralContext(ctx context.Context, channelID, userID s
 	return timestamp, err
 }
 
-// UpdateMessage updates a message in a channel
+// UpdateMessage updates a message in a channel.
+// For more details, see UpdateMessageContext documentation.
 func (api *Client) UpdateMessage(channelID, timestamp string, options ...MsgOption) (string, string, string, error) {
 	return api.UpdateMessageContext(context.Background(), channelID, timestamp, options...)
 }
 
-// UpdateMessageContext updates a message in a channel
+// UpdateMessageContext updates a message in a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.update
 func (api *Client) UpdateMessageContext(ctx context.Context, channelID, timestamp string, options ...MsgOption) (string, string, string, error) {
 	return api.SendMessageContext(
 		ctx,
@@ -175,38 +182,38 @@ func (api *Client) UpdateMessageContext(ctx context.Context, channelID, timestam
 	)
 }
 
-// UnfurlMessage unfurls a message in a channel
+// UnfurlMessage unfurls a message in a channel.
+// For more details, see UnfurlMessageContext documentation.
 func (api *Client) UnfurlMessage(channelID, timestamp string, unfurls map[string]Attachment, options ...MsgOption) (string, string, string, error) {
 	return api.UnfurlMessageContext(context.Background(), channelID, timestamp, unfurls, options...)
 }
 
-// UnfurlMessageContext unfurls a message in a channel with a custom context
+// UnfurlMessageContext unfurls a message in a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.unfurl
 func (api *Client) UnfurlMessageContext(ctx context.Context, channelID, timestamp string, unfurls map[string]Attachment, options ...MsgOption) (string, string, string, error) {
 	return api.SendMessageContext(ctx, channelID, MsgOptionUnfurl(timestamp, unfurls), MsgOptionCompose(options...))
 }
 
-// UnfurlMessageWithAuthURL sends an unfurl request containing an
-// authentication URL.
-// For more details see:
-// https://api.slack.com/reference/messaging/link-unfurling#authenticated_unfurls
+// UnfurlMessageWithAuthURL sends an unfurl request containing an authentication URL.
+// For more details, see UnfurlMessageWithAuthURLContext documentation.
 func (api *Client) UnfurlMessageWithAuthURL(channelID, timestamp string, userAuthURL string, options ...MsgOption) (string, string, string, error) {
 	return api.UnfurlMessageWithAuthURLContext(context.Background(), channelID, timestamp, userAuthURL, options...)
 }
 
-// UnfurlMessageWithAuthURLContext sends an unfurl request containing an
-// authentication URL.
-// For more details see:
-// https://api.slack.com/reference/messaging/link-unfurling#authenticated_unfurls
+// UnfurlMessageWithAuthURLContext sends an unfurl request containing an authentication URL with a custom context.
+// For more details see: https://api.slack.com/reference/messaging/link-unfurling#authenticated_unfurls
 func (api *Client) UnfurlMessageWithAuthURLContext(ctx context.Context, channelID, timestamp string, userAuthURL string, options ...MsgOption) (string, string, string, error) {
 	return api.SendMessageContext(ctx, channelID, MsgOptionUnfurlAuthURL(timestamp, userAuthURL), MsgOptionCompose(options...))
 }
 
 // SendMessage more flexible method for configuring messages.
+// For more details, see SendMessageContext documentation.
 func (api *Client) SendMessage(channel string, options ...MsgOption) (string, string, string, error) {
 	return api.SendMessageContext(context.Background(), channel, options...)
 }
 
 // SendMessageContext more flexible method for configuring messages with a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.postMessage
 func (api *Client) SendMessageContext(ctx context.Context, channelID string, options ...MsgOption) (_channel string, _timestamp string, _text string, err error) {
 	var (
 		req      *http.Request
@@ -219,12 +226,12 @@ func (api *Client) SendMessageContext(ctx context.Context, channelID string, opt
 	}
 
 	if api.Debug() {
-		reqBody, err := ioutil.ReadAll(req.Body)
+		reqBody, err := io.ReadAll(req.Body)
 		if err != nil {
 			return "", "", "", err
 		}
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBody))
-		api.Debugf("Sending request: %s", string(reqBody))
+		req.Body = io.NopCloser(bytes.NewBuffer(reqBody))
+		api.Debugf("Sending request: %s", redactToken(reqBody))
 	}
 
 	if err = doPost(ctx, api.httpclient, req, parser(&response), api); err != nil {
@@ -232,6 +239,20 @@ func (api *Client) SendMessageContext(ctx context.Context, channelID string, opt
 	}
 
 	return response.Channel, response.getMessageTimestamp(), response.Text, response.Err()
+}
+
+func redactToken(b []byte) []byte {
+	// See https://api.slack.com/authentication/token-types
+	// and https://api.slack.com/authentication/rotation
+	re, err := regexp.Compile(`(token=x[a-z.]+)-[0-9A-Za-z-]+`)
+	if err != nil {
+		// The regular expression above should never result in errors,
+		// but just in case, do no harm.
+		return b
+	}
+	// Keep "token=" and the first element of the token, which identifies its type
+	// (this could be useful for debugging, e.g. when using a wrong token).
+	return re.ReplaceAll(b, []byte("$1-REDACTED"))
 }
 
 // UnsafeApplyMsgOptions utility function for debugging/testing chat requests.
@@ -356,6 +377,7 @@ func (t responseURLSender) BuildRequestContext(ctx context.Context) (*http.Reque
 	req, err := jsonReq(ctx, t.endpoint, Msg{
 		Text:            t.values.Get("text"),
 		Timestamp:       t.values.Get("ts"),
+		ThreadTimestamp: t.values.Get("thread_ts"),
 		Attachments:     t.attachments,
 		Blocks:          t.blocks,
 		Metadata:        t.metadata,
@@ -681,6 +703,14 @@ func MsgOptionMetadata(metadata SlackMetadata) MsgOption {
 	}
 }
 
+// MsgOptionLinkNames finds and links user groups. Does not support linking individual users
+func MsgOptionLinkNames(linkName bool) MsgOption {
+	return func(config *sendConfig) error {
+		config.values.Set("link_names", strconv.FormatBool(linkName))
+		return nil
+	}
+}
+
 // UnsafeMsgOptionEndpoint deliver the message to the specified endpoint.
 // NOTE: USE AT YOUR OWN RISK: No issues relating to the use of this Option
 // will be supported by the library, it is subject to change without notice that
@@ -748,22 +778,21 @@ func MsgOptionPostMessageParameters(params PostMessageParameters) MsgOption {
 	}
 }
 
-// PermalinkParameters are the parameters required to get a permalink to a
-// message. Slack documentation can be found here:
-// https://api.slack.com/methods/chat.getPermalink
+// PermalinkParameters are the parameters required to get a permalink to a message.
 type PermalinkParameters struct {
 	Channel string
 	Ts      string
 }
 
-// GetPermalink returns the permalink for a message. It takes
-// PermalinkParameters and returns a string containing the permalink. It
-// returns an error if unable to retrieve the permalink.
+// GetPermalink returns the permalink for a message. It takes PermalinkParameters and returns a string containing the
+// permalink. It returns an error if unable to retrieve the permalink.
+// For more details, see GetPermalinkContext documentation.
 func (api *Client) GetPermalink(params *PermalinkParameters) (string, error) {
 	return api.GetPermalinkContext(context.Background(), params)
 }
 
 // GetPermalinkContext returns the permalink for a message using a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.getPermalink
 func (api *Client) GetPermalinkContext(ctx context.Context, params *PermalinkParameters) (string, error) {
 	values := url.Values{
 		"channel":    {params.Channel},
@@ -784,24 +813,30 @@ func (api *Client) GetPermalinkContext(ctx context.Context, params *PermalinkPar
 
 type GetScheduledMessagesParameters struct {
 	Channel string
+	TeamID  string
 	Cursor  string
 	Latest  string
 	Limit   int
 	Oldest  string
 }
 
-// GetScheduledMessages returns the list of scheduled messages based on params
+// GetScheduledMessages returns the list of scheduled messages based on params.
+// For more details, see GetScheduledMessagesContext documentation.
 func (api *Client) GetScheduledMessages(params *GetScheduledMessagesParameters) (channels []ScheduledMessage, nextCursor string, err error) {
 	return api.GetScheduledMessagesContext(context.Background(), params)
 }
 
-// GetScheduledMessagesContext returns the list of scheduled messages in a Slack team with a custom context
+// GetScheduledMessagesContext returns the list of scheduled messages based on params with a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.getScheduledMessages.list
 func (api *Client) GetScheduledMessagesContext(ctx context.Context, params *GetScheduledMessagesParameters) (channels []ScheduledMessage, nextCursor string, err error) {
 	values := url.Values{
 		"token": {api.token},
 	}
 	if params.Channel != "" {
 		values.Add("channel", params.Channel)
+	}
+	if params.TeamID != "" {
+		values.Add("team_id", params.TeamID)
 	}
 	if params.Cursor != "" {
 		values.Add("cursor", params.Cursor)
@@ -835,12 +870,14 @@ type DeleteScheduledMessageParameters struct {
 	AsUser             bool
 }
 
-// DeleteScheduledMessage returns the list of scheduled messages based on params
+// DeleteScheduledMessage deletes a pending scheduled message.
+// For more details, see DeleteScheduledMessageContext documentation.
 func (api *Client) DeleteScheduledMessage(params *DeleteScheduledMessageParameters) (bool, error) {
 	return api.DeleteScheduledMessageContext(context.Background(), params)
 }
 
-// DeleteScheduledMessageContext returns the list of scheduled messages in a Slack team with a custom context
+// DeleteScheduledMessageContext deletes a pending scheduled message with a custom context.
+// Slack API docs: https://api.slack.com/methods/chat.deleteScheduledMessage
 func (api *Client) DeleteScheduledMessageContext(ctx context.Context, params *DeleteScheduledMessageParameters) (bool, error) {
 	values := url.Values{
 		"token":                {api.token},

--- a/vendor/github.com/slack-go/slack/conversation.go
+++ b/vendor/github.com/slack-go/slack/conversation.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/url"
 	"strconv"
@@ -22,14 +23,19 @@ type Conversation struct {
 	IsIM               bool     `json:"is_im"`
 	IsExtShared        bool     `json:"is_ext_shared"`
 	IsOrgShared        bool     `json:"is_org_shared"`
+	IsGlobalShared     bool     `json:"is_global_shared"`
 	IsPendingExtShared bool     `json:"is_pending_ext_shared"`
 	IsPrivate          bool     `json:"is_private"`
+	IsReadOnly         bool     `json:"is_read_only"`
 	IsMpIM             bool     `json:"is_mpim"`
 	Unlinked           int      `json:"unlinked"`
 	NameNormalized     string   `json:"name_normalized"`
 	NumMembers         int      `json:"num_members"`
 	Priority           float64  `json:"priority"`
 	User               string   `json:"user"`
+	ConnectedTeamIDs   []string `json:"connected_team_ids,omitempty"`
+	SharedTeamIDs      []string `json:"shared_team_ids,omitempty"`
+	InternalTeamIDs    []string `json:"internal_team_ids,omitempty"`
 
 	// TODO support pending_shared
 	// TODO support previous_names
@@ -60,6 +66,17 @@ type Purpose struct {
 	LastSet JSONTime `json:"last_set"`
 }
 
+// Properties contains the Canvas associated to the channel.
+type Properties struct {
+	Canvas Canvas `json:"canvas"`
+}
+
+type Canvas struct {
+	FileId       string `json:"file_id"`
+	IsEmpty      bool   `json:"is_empty"`
+	QuipThreadId string `json:"quip_thread_id"`
+}
+
 type GetUsersInConversationParameters struct {
 	ChannelID string
 	Cursor    string
@@ -79,12 +96,14 @@ type responseMetaData struct {
 	NextCursor string `json:"next_cursor"`
 }
 
-// GetUsersInConversation returns the list of users in a conversation
+// GetUsersInConversation returns the list of users in a conversation.
+// For more details, see GetUsersInConversationContext documentation.
 func (api *Client) GetUsersInConversation(params *GetUsersInConversationParameters) ([]string, string, error) {
 	return api.GetUsersInConversationContext(context.Background(), params)
 }
 
-// GetUsersInConversationContext returns the list of users in a conversation with a custom context
+// GetUsersInConversationContext returns the list of users in a conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.members
 func (api *Client) GetUsersInConversationContext(ctx context.Context, params *GetUsersInConversationParameters) ([]string, string, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -114,12 +133,14 @@ func (api *Client) GetUsersInConversationContext(ctx context.Context, params *Ge
 	return response.Members, response.ResponseMetaData.NextCursor, nil
 }
 
-// GetConversationsForUser returns the list conversations for a given user
+// GetConversationsForUser returns the list conversations for a given user.
+// For more details, see GetConversationsForUserContext documentation.
 func (api *Client) GetConversationsForUser(params *GetConversationsForUserParameters) (channels []Channel, nextCursor string, err error) {
 	return api.GetConversationsForUserContext(context.Background(), params)
 }
 
 // GetConversationsForUserContext returns the list conversations for a given user with a custom context
+// Slack API docs: https://api.slack.com/methods/users.conversations
 func (api *Client) GetConversationsForUserContext(ctx context.Context, params *GetConversationsForUserParameters) (channels []Channel, nextCursor string, err error) {
 	values := url.Values{
 		"token": {api.token},
@@ -156,12 +177,14 @@ func (api *Client) GetConversationsForUserContext(ctx context.Context, params *G
 	return response.Channels, response.ResponseMetaData.NextCursor, response.Err()
 }
 
-// ArchiveConversation archives a conversation
+// ArchiveConversation archives a conversation.
+// For more details, see ArchiveConversationContext documentation.
 func (api *Client) ArchiveConversation(channelID string) error {
 	return api.ArchiveConversationContext(context.Background(), channelID)
 }
 
-// ArchiveConversationContext archives a conversation with a custom context
+// ArchiveConversationContext archives a conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.archive
 func (api *Client) ArchiveConversationContext(ctx context.Context, channelID string) error {
 	values := url.Values{
 		"token":   {api.token},
@@ -177,12 +200,14 @@ func (api *Client) ArchiveConversationContext(ctx context.Context, channelID str
 	return response.Err()
 }
 
-// UnArchiveConversation reverses conversation archival
+// UnArchiveConversation reverses conversation archival.
+// For more details, see UnArchiveConversationContext documentation.
 func (api *Client) UnArchiveConversation(channelID string) error {
 	return api.UnArchiveConversationContext(context.Background(), channelID)
 }
 
-// UnArchiveConversationContext reverses conversation archival with a custom context
+// UnArchiveConversationContext reverses conversation archival with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.unarchive
 func (api *Client) UnArchiveConversationContext(ctx context.Context, channelID string) error {
 	values := url.Values{
 		"token":   {api.token},
@@ -197,12 +222,14 @@ func (api *Client) UnArchiveConversationContext(ctx context.Context, channelID s
 	return response.Err()
 }
 
-// SetTopicOfConversation sets the topic for a conversation
+// SetTopicOfConversation sets the topic for a conversation.
+// For more details, see SetTopicOfConversationContext documentation.
 func (api *Client) SetTopicOfConversation(channelID, topic string) (*Channel, error) {
 	return api.SetTopicOfConversationContext(context.Background(), channelID, topic)
 }
 
-// SetTopicOfConversationContext sets the topic for a conversation with a custom context
+// SetTopicOfConversationContext sets the topic for a conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.setTopic
 func (api *Client) SetTopicOfConversationContext(ctx context.Context, channelID, topic string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -221,12 +248,14 @@ func (api *Client) SetTopicOfConversationContext(ctx context.Context, channelID,
 	return response.Channel, response.Err()
 }
 
-// SetPurposeOfConversation sets the purpose for a conversation
+// SetPurposeOfConversation sets the purpose for a conversation.
+// For more details, see SetPurposeOfConversationContext documentation.
 func (api *Client) SetPurposeOfConversation(channelID, purpose string) (*Channel, error) {
 	return api.SetPurposeOfConversationContext(context.Background(), channelID, purpose)
 }
 
-// SetPurposeOfConversationContext sets the purpose for a conversation with a custom context
+// SetPurposeOfConversationContext sets the purpose for a conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.setPurpose
 func (api *Client) SetPurposeOfConversationContext(ctx context.Context, channelID, purpose string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -246,12 +275,14 @@ func (api *Client) SetPurposeOfConversationContext(ctx context.Context, channelI
 	return response.Channel, response.Err()
 }
 
-// RenameConversation renames a conversation
+// RenameConversation renames a conversation.
+// For more details, see RenameConversationContext documentation.
 func (api *Client) RenameConversation(channelID, channelName string) (*Channel, error) {
 	return api.RenameConversationContext(context.Background(), channelID, channelName)
 }
 
-// RenameConversationContext renames a conversation with a custom context
+// RenameConversationContext renames a conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.rename
 func (api *Client) RenameConversationContext(ctx context.Context, channelID, channelName string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -271,12 +302,14 @@ func (api *Client) RenameConversationContext(ctx context.Context, channelID, cha
 	return response.Channel, response.Err()
 }
 
-// InviteUsersToConversation invites users to a channel
+// InviteUsersToConversation invites users to a channel.
+// For more details, see InviteUsersToConversation documentation.
 func (api *Client) InviteUsersToConversation(channelID string, users ...string) (*Channel, error) {
 	return api.InviteUsersToConversationContext(context.Background(), channelID, users...)
 }
 
-// InviteUsersToConversationContext invites users to a channel with a custom context
+// InviteUsersToConversationContext invites users to a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.invite
 func (api *Client) InviteUsersToConversationContext(ctx context.Context, channelID string, users ...string) (*Channel, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -296,12 +329,95 @@ func (api *Client) InviteUsersToConversationContext(ctx context.Context, channel
 	return response.Channel, response.Err()
 }
 
-// KickUserFromConversation removes a user from a conversation
+// InviteSharedEmailsToConversation invites users to a shared channels by email.
+// For more details, see InviteSharedToConversationContext documentation.
+func (api *Client) InviteSharedEmailsToConversation(channelID string, emails ...string) (string, bool, error) {
+	return api.InviteSharedToConversationContext(context.Background(), InviteSharedToConversationParams{
+		ChannelID: channelID,
+		Emails:    emails,
+	})
+}
+
+// InviteSharedEmailsToConversationContext invites users to a shared channels by email using context.
+// For more details, see InviteSharedToConversationContext documentation.
+func (api *Client) InviteSharedEmailsToConversationContext(ctx context.Context, channelID string, emails ...string) (string, bool, error) {
+	return api.InviteSharedToConversationContext(ctx, InviteSharedToConversationParams{
+		ChannelID: channelID,
+		Emails:    emails,
+	})
+}
+
+// InviteSharedUserIDsToConversation invites users to a shared channels by user id.
+// For more details, see InviteSharedToConversationContext documentation.
+func (api *Client) InviteSharedUserIDsToConversation(channelID string, userIDs ...string) (string, bool, error) {
+	return api.InviteSharedToConversationContext(context.Background(), InviteSharedToConversationParams{
+		ChannelID: channelID,
+		UserIDs:   userIDs,
+	})
+}
+
+// InviteSharedUserIDsToConversationContext invites users to a shared channels by user id with context.
+// For more details, see InviteSharedToConversationContext documentation.
+func (api *Client) InviteSharedUserIDsToConversationContext(ctx context.Context, channelID string, userIDs ...string) (string, bool, error) {
+	return api.InviteSharedToConversationContext(ctx, InviteSharedToConversationParams{
+		ChannelID: channelID,
+		UserIDs:   userIDs,
+	})
+}
+
+// InviteSharedToConversationParams defines the parameters for the InviteSharedToConversation and InviteSharedToConversationContext functions.
+type InviteSharedToConversationParams struct {
+	ChannelID       string
+	Emails          []string
+	UserIDs         []string
+	ExternalLimited *bool
+}
+
+// InviteSharedToConversation invites emails or userIDs to a channel.
+// For more details, see InviteSharedToConversationContext documentation.
+func (api *Client) InviteSharedToConversation(params InviteSharedToConversationParams) (string, bool, error) {
+	return api.InviteSharedToConversationContext(context.Background(), params)
+}
+
+// InviteSharedToConversationContext invites emails or userIDs to a channel with a custom context.
+// This is a helper function for InviteSharedEmailsToConversation and InviteSharedUserIDsToConversation.
+// It accepts either emails or userIDs, but not both.
+// Slack API docs: https://api.slack.com/methods/conversations.inviteShared
+func (api *Client) InviteSharedToConversationContext(ctx context.Context, params InviteSharedToConversationParams) (string, bool, error) {
+	values := url.Values{
+		"token":   {api.token},
+		"channel": {params.ChannelID},
+	}
+	if len(params.Emails) > 0 {
+		values.Add("emails", strings.Join(params.Emails, ","))
+	} else if len(params.UserIDs) > 0 {
+		values.Add("user_ids", strings.Join(params.UserIDs, ","))
+	}
+	if params.ExternalLimited != nil {
+		values.Add("external_limited", strconv.FormatBool(*params.ExternalLimited))
+	}
+	response := struct {
+		SlackResponse
+		InviteID              string `json:"invite_id"`
+		IsLegacySharedChannel bool   `json:"is_legacy_shared_channel"`
+	}{}
+
+	err := api.postMethod(ctx, "conversations.inviteShared", values, &response)
+	if err != nil {
+		return "", false, err
+	}
+
+	return response.InviteID, response.IsLegacySharedChannel, response.Err()
+}
+
+// KickUserFromConversation removes a user from a conversation.
+// For more details, see KickUserFromConversationContext documentation.
 func (api *Client) KickUserFromConversation(channelID string, user string) error {
 	return api.KickUserFromConversationContext(context.Background(), channelID, user)
 }
 
-// KickUserFromConversationContext removes a user from a conversation with a custom context
+// KickUserFromConversationContext removes a user from a conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.kick
 func (api *Client) KickUserFromConversationContext(ctx context.Context, channelID string, user string) error {
 	values := url.Values{
 		"token":   {api.token},
@@ -318,12 +434,14 @@ func (api *Client) KickUserFromConversationContext(ctx context.Context, channelI
 	return response.Err()
 }
 
-// CloseConversation closes a direct message or multi-person direct message
+// CloseConversation closes a direct message or multi-person direct message.
+// For more details, see CloseConversationContext documentation.
 func (api *Client) CloseConversation(channelID string) (noOp bool, alreadyClosed bool, err error) {
 	return api.CloseConversationContext(context.Background(), channelID)
 }
 
-// CloseConversationContext closes a direct message or multi-person direct message with a custom context
+// CloseConversationContext closes a direct message or multi-person direct message with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.close
 func (api *Client) CloseConversationContext(ctx context.Context, channelID string) (noOp bool, alreadyClosed bool, err error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -349,12 +467,14 @@ type CreateConversationParams struct {
 	TeamID      string
 }
 
-// CreateConversation initiates a public or private channel-based conversation
+// CreateConversation initiates a public or private channel-based conversation.
+// For more details, see CreateConversationContext documentation.
 func (api *Client) CreateConversation(params CreateConversationParams) (*Channel, error) {
 	return api.CreateConversationContext(context.Background(), params)
 }
 
-// CreateConversationContext initiates a public or private channel-based conversation with a custom context
+// CreateConversationContext initiates a public or private channel-based conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.create
 func (api *Client) CreateConversationContext(ctx context.Context, params CreateConversationParams) (*Channel, error) {
 	values := url.Values{
 		"token":      {api.token},
@@ -379,12 +499,14 @@ type GetConversationInfoInput struct {
 	IncludeNumMembers bool
 }
 
-// GetConversationInfo retrieves information about a conversation
+// GetConversationInfo retrieves information about a conversation.
+// For more details, see GetConversationInfoContext documentation.
 func (api *Client) GetConversationInfo(input *GetConversationInfoInput) (*Channel, error) {
 	return api.GetConversationInfoContext(context.Background(), input)
 }
 
-// GetConversationInfoContext retrieves information about a conversation with a custom context
+// GetConversationInfoContext retrieves information about a conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.info
 func (api *Client) GetConversationInfoContext(ctx context.Context, input *GetConversationInfoInput) (*Channel, error) {
 	if input == nil {
 		return nil, errors.New("GetConversationInfoInput must not be nil")
@@ -408,12 +530,14 @@ func (api *Client) GetConversationInfoContext(ctx context.Context, input *GetCon
 	return &response.Channel, response.Err()
 }
 
-// LeaveConversation leaves a conversation
+// LeaveConversation leaves a conversation.
+// For more details, see LeaveConversationContext documentation.
 func (api *Client) LeaveConversation(channelID string) (bool, error) {
 	return api.LeaveConversationContext(context.Background(), channelID)
 }
 
-// LeaveConversationContext leaves a conversation with a custom context
+// LeaveConversationContext leaves a conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.leave
 func (api *Client) LeaveConversationContext(ctx context.Context, channelID string) (bool, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -439,12 +563,14 @@ type GetConversationRepliesParameters struct {
 	IncludeAllMetadata bool
 }
 
-// GetConversationReplies retrieves a thread of messages posted to a conversation
+// GetConversationReplies retrieves a thread of messages posted to a conversation.
+// For more details, see GetConversationRepliesContext documentation.
 func (api *Client) GetConversationReplies(params *GetConversationRepliesParameters) (msgs []Message, hasMore bool, nextCursor string, err error) {
 	return api.GetConversationRepliesContext(context.Background(), params)
 }
 
-// GetConversationRepliesContext retrieves a thread of messages posted to a conversation with a custom context
+// GetConversationRepliesContext retrieves a thread of messages posted to a conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.replies
 func (api *Client) GetConversationRepliesContext(ctx context.Context, params *GetConversationRepliesParameters) (msgs []Message, hasMore bool, nextCursor string, err error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -498,12 +624,14 @@ type GetConversationsParameters struct {
 	TeamID          string
 }
 
-// GetConversations returns the list of channels in a Slack team
+// GetConversations returns the list of channels in a Slack team.
+// For more details, see GetConversationsContext documentation.
 func (api *Client) GetConversations(params *GetConversationsParameters) (channels []Channel, nextCursor string, err error) {
 	return api.GetConversationsContext(context.Background(), params)
 }
 
-// GetConversationsContext returns the list of channels in a Slack team with a custom context
+// GetConversationsContext returns the list of channels in a Slack team with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.list
 func (api *Client) GetConversationsContext(ctx context.Context, params *GetConversationsParameters) (channels []Channel, nextCursor string, err error) {
 	values := url.Values{
 		"token": {api.token},
@@ -544,12 +672,14 @@ type OpenConversationParameters struct {
 	Users     []string
 }
 
-// OpenConversation opens or resumes a direct message or multi-person direct message
+// OpenConversation opens or resumes a direct message or multi-person direct message.
+// For more details, see OpenConversationContext documentation.
 func (api *Client) OpenConversation(params *OpenConversationParameters) (*Channel, bool, bool, error) {
 	return api.OpenConversationContext(context.Background(), params)
 }
 
-// OpenConversationContext opens or resumes a direct message or multi-person direct message with a custom context
+// OpenConversationContext opens or resumes a direct message or multi-person direct message with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.open
 func (api *Client) OpenConversationContext(ctx context.Context, params *OpenConversationParameters) (*Channel, bool, bool, error) {
 	values := url.Values{
 		"token":     {api.token},
@@ -576,12 +706,14 @@ func (api *Client) OpenConversationContext(ctx context.Context, params *OpenConv
 	return response.Channel, response.NoOp, response.AlreadyOpen, response.Err()
 }
 
-// JoinConversation joins an existing conversation
+// JoinConversation joins an existing conversation.
+// For more details, see JoinConversationContext documentation.
 func (api *Client) JoinConversation(channelID string) (*Channel, string, []string, error) {
 	return api.JoinConversationContext(context.Background(), channelID)
 }
 
-// JoinConversationContext joins an existing conversation with a custom context
+// JoinConversationContext joins an existing conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.join
 func (api *Client) JoinConversationContext(ctx context.Context, channelID string) (*Channel, string, []string, error) {
 	values := url.Values{"token": {api.token}, "channel": {channelID}}
 	response := struct {
@@ -628,12 +760,14 @@ type GetConversationHistoryResponse struct {
 	Messages []Message `json:"messages"`
 }
 
-// GetConversationHistory joins an existing conversation
+// GetConversationHistory joins an existing conversation.
+// For more details, see GetConversationHistoryContext documentation.
 func (api *Client) GetConversationHistory(params *GetConversationHistoryParameters) (*GetConversationHistoryResponse, error) {
 	return api.GetConversationHistoryContext(context.Background(), params)
 }
 
-// GetConversationHistoryContext joins an existing conversation with a custom context
+// GetConversationHistoryContext joins an existing conversation with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.history
 func (api *Client) GetConversationHistoryContext(ctx context.Context, params *GetConversationHistoryParameters) (*GetConversationHistoryResponse, error) {
 	values := url.Values{"token": {api.token}, "channel": {params.ChannelID}}
 	if params.Cursor != "" {
@@ -669,12 +803,14 @@ func (api *Client) GetConversationHistoryContext(ctx context.Context, params *Ge
 	return &response, response.Err()
 }
 
-// MarkConversation sets the read mark of a conversation to a specific point
+// MarkConversation sets the read mark of a conversation to a specific point.
+// For more details, see MarkConversationContext documentation.
 func (api *Client) MarkConversation(channel, ts string) (err error) {
 	return api.MarkConversationContext(context.Background(), channel, ts)
 }
 
-// MarkConversationContext sets the read mark of a conversation to a specific point with a custom context
+// MarkConversationContext sets the read mark of a conversation to a specific point with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.mark
 func (api *Client) MarkConversationContext(ctx context.Context, channel, ts string) error {
 	values := url.Values{
 		"token":   {api.token},
@@ -689,4 +825,37 @@ func (api *Client) MarkConversationContext(ctx context.Context, channel, ts stri
 		return err
 	}
 	return response.Err()
+}
+
+// CreateChannelCanvas creates a new canvas in a channel.
+// For more details, see CreateChannelCanvasContext documentation.
+func (api *Client) CreateChannelCanvas(channel string, documentContent DocumentContent) (string, error) {
+	return api.CreateChannelCanvasContext(context.Background(), channel, documentContent)
+}
+
+// CreateChannelCanvasContext creates a new canvas in a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/conversations.canvases.create
+func (api *Client) CreateChannelCanvasContext(ctx context.Context, channel string, documentContent DocumentContent) (string, error) {
+	values := url.Values{
+		"token":      {api.token},
+		"channel_id": {channel},
+	}
+	if documentContent.Type != "" {
+		documentContentJSON, err := json.Marshal(documentContent)
+		if err != nil {
+			return "", err
+		}
+		values.Add("document_content", string(documentContentJSON))
+	}
+
+	response := struct {
+		SlackResponse
+		CanvasID string `json:"canvas_id"`
+	}{}
+	err := api.postMethod(ctx, "conversations.canvases.create", values, &response)
+	if err != nil {
+		return "", err
+	}
+
+	return response.CanvasID, response.Err()
 }

--- a/vendor/github.com/slack-go/slack/dnd.go
+++ b/vendor/github.com/slack-go/slack/dnd.go
@@ -45,12 +45,14 @@ func (api *Client) dndRequest(ctx context.Context, path string, values url.Value
 	return response, response.Err()
 }
 
-// EndDND ends the user's scheduled Do Not Disturb session
+// EndDND ends the user's scheduled Do Not Disturb session.
+// For more information see the EndDNDContext documentation.
 func (api *Client) EndDND() error {
 	return api.EndDNDContext(context.Background())
 }
 
-// EndDNDContext ends the user's scheduled Do Not Disturb session with a custom context
+// EndDNDContext ends the user's scheduled Do Not Disturb session with a custom context.
+// Slack API docs: https://api.slack.com/methods/dnd.endDnd
 func (api *Client) EndDNDContext(ctx context.Context) error {
 	values := url.Values{
 		"token": {api.token},
@@ -65,12 +67,14 @@ func (api *Client) EndDNDContext(ctx context.Context) error {
 	return response.Err()
 }
 
-// EndSnooze ends the current user's snooze mode
+// EndSnooze ends the current user's snooze mode.
+// For more information see the EndSnoozeContext documentation.
 func (api *Client) EndSnooze() (*DNDStatus, error) {
 	return api.EndSnoozeContext(context.Background())
 }
 
-// EndSnoozeContext ends the current user's snooze mode with a custom context
+// EndSnoozeContext ends the current user's snooze mode with a custom context.
+// Slack API docs: https://api.slack.com/methods/dnd.endSnooze
 func (api *Client) EndSnoozeContext(ctx context.Context) (*DNDStatus, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -84,11 +88,13 @@ func (api *Client) EndSnoozeContext(ctx context.Context) (*DNDStatus, error) {
 }
 
 // GetDNDInfo provides information about a user's current Do Not Disturb settings.
+// For more information see the GetDNDInfoContext documentation.
 func (api *Client) GetDNDInfo(user *string) (*DNDStatus, error) {
 	return api.GetDNDInfoContext(context.Background(), user)
 }
 
 // GetDNDInfoContext provides information about a user's current Do Not Disturb settings with a custom context.
+// Slack API docs: https://api.slack.com/methods/dnd.info
 func (api *Client) GetDNDInfoContext(ctx context.Context, user *string) (*DNDStatus, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -105,11 +111,13 @@ func (api *Client) GetDNDInfoContext(ctx context.Context, user *string) (*DNDSta
 }
 
 // GetDNDTeamInfo provides information about a user's current Do Not Disturb settings.
+// For more information see the GetDNDTeamInfoContext documentation.
 func (api *Client) GetDNDTeamInfo(users []string) (map[string]DNDStatus, error) {
 	return api.GetDNDTeamInfoContext(context.Background(), users)
 }
 
 // GetDNDTeamInfoContext provides information about a user's current Do Not Disturb settings with a custom context.
+// Slack API docs: https://api.slack.com/methods/dnd.teamInfo
 func (api *Client) GetDNDTeamInfoContext(ctx context.Context, users []string) (map[string]DNDStatus, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -128,15 +136,16 @@ func (api *Client) GetDNDTeamInfoContext(ctx context.Context, users []string) (m
 	return response.Users, nil
 }
 
-// SetSnooze adjusts the snooze duration for a user's Do Not Disturb
-// settings. If a snooze session is not already active for the user, invoking
-// this method will begin one for the specified duration.
+// SetSnooze adjusts the snooze duration for a user's Do Not Disturb settings.
+// For more information see the SetSnoozeContext documentation.
 func (api *Client) SetSnooze(minutes int) (*DNDStatus, error) {
 	return api.SetSnoozeContext(context.Background(), minutes)
 }
 
-// SetSnoozeContext adjusts the snooze duration for a user's Do Not Disturb settings with a custom context.
-// For more information see the SetSnooze docs
+// SetSnoozeContext adjusts the snooze duration for a user's Do Not Disturb settings.
+// If a snooze session is not already active for the user, invoking this method will
+// begin one for the specified duration.
+// Slack API docs: https://api.slack.com/methods/dnd.setSnooze
 func (api *Client) SetSnoozeContext(ctx context.Context, minutes int) (*DNDStatus, error) {
 	values := url.Values{
 		"token":       {api.token},

--- a/vendor/github.com/slack-go/slack/emoji.go
+++ b/vendor/github.com/slack-go/slack/emoji.go
@@ -10,12 +10,14 @@ type emojiResponseFull struct {
 	SlackResponse
 }
 
-// GetEmoji retrieves all the emojis
+// GetEmoji retrieves all the emojis.
+// For more details see GetEmojiContext documentation.
 func (api *Client) GetEmoji() (map[string]string, error) {
 	return api.GetEmojiContext(context.Background())
 }
 
-// GetEmojiContext retrieves all the emojis with a custom context
+// GetEmojiContext retrieves all the emojis with a custom context.
+// Slack API docs: https://api.slack.com/methods/emoji.list
 func (api *Client) GetEmojiContext(ctx context.Context) (map[string]string, error) {
 	values := url.Values{
 		"token": {api.token},

--- a/vendor/github.com/slack-go/slack/files.go
+++ b/vendor/github.com/slack-go/slack/files.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	// Add here the defaults in the siten
+	// Add here the defaults in the site
 	DEFAULT_FILES_USER        = ""
 	DEFAULT_FILES_CHANNEL     = ""
 	DEFAULT_FILES_TS_FROM     = 0
@@ -129,6 +129,7 @@ type FileUploadParameters struct {
 type GetFilesParameters struct {
 	User          string
 	Channel       string
+	TeamID        string
 	TimestampFrom JSONTime
 	TimestampTo   JSONTime
 	Types         string
@@ -142,6 +143,7 @@ type ListFilesParameters struct {
 	Limit   int
 	User    string
 	Channel string
+	TeamID  string
 	Types   string
 	Cursor  string
 }
@@ -232,12 +234,14 @@ func (api *Client) fileRequest(ctx context.Context, path string, values url.Valu
 	return response, response.Err()
 }
 
-// GetFileInfo retrieves a file and related comments
+// GetFileInfo retrieves a file and related comments.
+// For more details, see GetFileInfoContext documentation.
 func (api *Client) GetFileInfo(fileID string, count, page int) (*File, []Comment, *Paging, error) {
 	return api.GetFileInfoContext(context.Background(), fileID, count, page)
 }
 
-// GetFileInfoContext retrieves a file and related comments with a custom context
+// GetFileInfoContext retrieves a file and related comments with a custom context.
+// Slack API docs: https://api.slack.com/methods/files.info
 func (api *Client) GetFileInfoContext(ctx context.Context, fileID string, count, page int) (*File, []Comment, *Paging, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -253,24 +257,25 @@ func (api *Client) GetFileInfoContext(ctx context.Context, fileID string, count,
 	return &response.File, response.Comments, &response.Paging, nil
 }
 
-// GetFile retreives a given file from its private download URL
+// GetFile retrieves a given file from its private download URL.
 func (api *Client) GetFile(downloadURL string, writer io.Writer) error {
 	return api.GetFileContext(context.Background(), downloadURL, writer)
 }
 
-// GetFileContext retreives a given file from its private download URL with a custom context
-//
+// GetFileContext retrieves a given file from its private download URL with a custom context.
 // For more details, see GetFile documentation.
 func (api *Client) GetFileContext(ctx context.Context, downloadURL string, writer io.Writer) error {
 	return downloadFile(ctx, api.httpclient, api.token, downloadURL, writer, api)
 }
 
-// GetFiles retrieves all files according to the parameters given
+// GetFiles retrieves all files according to the parameters given.
+// For more details, see GetFilesContext documentation.
 func (api *Client) GetFiles(params GetFilesParameters) ([]File, *Paging, error) {
 	return api.GetFilesContext(context.Background(), params)
 }
 
-// GetFilesContext retrieves all files according to the parameters given with a custom context
+// GetFilesContext retrieves all files according to the parameters given with a custom context.
+// Slack API docs: https://api.slack.com/methods/files.list
 func (api *Client) GetFilesContext(ctx context.Context, params GetFilesParameters) ([]File, *Paging, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -280,6 +285,9 @@ func (api *Client) GetFilesContext(ctx context.Context, params GetFilesParameter
 	}
 	if params.Channel != DEFAULT_FILES_CHANNEL {
 		values.Add("channel", params.Channel)
+	}
+	if params.TeamID != "" {
+		values.Add("team_id", params.TeamID)
 	}
 	if params.TimestampFrom != DEFAULT_FILES_TS_FROM {
 		values.Add("ts_from", strconv.FormatInt(int64(params.TimestampFrom), 10))
@@ -308,13 +316,13 @@ func (api *Client) GetFilesContext(ctx context.Context, params GetFilesParameter
 }
 
 // ListFiles retrieves all files according to the parameters given. Uses cursor based pagination.
+// For more details, see ListFilesContext documentation.
 func (api *Client) ListFiles(params ListFilesParameters) ([]File, *ListFilesParameters, error) {
 	return api.ListFilesContext(context.Background(), params)
 }
 
 // ListFilesContext retrieves all files according to the parameters given with a custom context.
-//
-// For more details, see ListFiles documentation.
+// Slack API docs: https://api.slack.com/methods/files.list
 func (api *Client) ListFilesContext(ctx context.Context, params ListFilesParameters) ([]File, *ListFilesParameters, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -325,6 +333,9 @@ func (api *Client) ListFilesContext(ctx context.Context, params ListFilesParamet
 	}
 	if params.Channel != DEFAULT_FILES_CHANNEL {
 		values.Add("channel", params.Channel)
+	}
+	if params.TeamID != "" {
+		values.Add("team_id", params.TeamID)
 	}
 	if params.Limit != DEFAULT_FILES_COUNT {
 		values.Add("limit", strconv.Itoa(params.Limit))
@@ -343,12 +354,18 @@ func (api *Client) ListFilesContext(ctx context.Context, params ListFilesParamet
 	return response.Files, &params, nil
 }
 
-// UploadFile uploads a file
+// UploadFile uploads a file.
+//
+// Deprecated: Use [Client.UploadFileV2] instead. This will stop functioning on March 11, 2025.
+// For more details, see: https://api.slack.com/methods/files.upload#markdown
 func (api *Client) UploadFile(params FileUploadParameters) (file *File, err error) {
 	return api.UploadFileContext(context.Background(), params)
 }
 
-// UploadFileContext uploads a file and setting a custom context
+// UploadFileContext uploads a file and setting a custom context.
+//
+// Deprecated: Use [Client.UploadFileV2Context] instead. This will stop functioning on March 11, 2025.
+// For more details, see: https://api.slack.com/methods/files.upload#markdown
 func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParameters) (file *File, err error) {
 	// Test if user token is valid. This helps because client.Do doesn't like this for some reason. XXX: More
 	// investigation needed, but for now this will do.
@@ -396,12 +413,14 @@ func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParam
 	return &response.File, response.Err()
 }
 
-// DeleteFileComment deletes a file's comment
+// DeleteFileComment deletes a file's comment.
+// For more details, see DeleteFileCommentContext documentation.
 func (api *Client) DeleteFileComment(commentID, fileID string) error {
 	return api.DeleteFileCommentContext(context.Background(), fileID, commentID)
 }
 
-// DeleteFileCommentContext deletes a file's comment with a custom context
+// DeleteFileCommentContext deletes a file's comment with a custom context.
+// Slack API docs: https://api.slack.com/methods/files.comments.delete
 func (api *Client) DeleteFileCommentContext(ctx context.Context, fileID, commentID string) (err error) {
 	if fileID == "" || commentID == "" {
 		return ErrParametersMissing
@@ -416,12 +435,14 @@ func (api *Client) DeleteFileCommentContext(ctx context.Context, fileID, comment
 	return err
 }
 
-// DeleteFile deletes a file
+// DeleteFile deletes a file.
+// For more details, see DeleteFileContext documentation.
 func (api *Client) DeleteFile(fileID string) error {
 	return api.DeleteFileContext(context.Background(), fileID)
 }
 
-// DeleteFileContext deletes a file with a custom context
+// DeleteFileContext deletes a file with a custom context.
+// Slack API docs: https://api.slack.com/methods/files.delete
 func (api *Client) DeleteFileContext(ctx context.Context, fileID string) (err error) {
 	values := url.Values{
 		"token": {api.token},
@@ -432,12 +453,14 @@ func (api *Client) DeleteFileContext(ctx context.Context, fileID string) (err er
 	return err
 }
 
-// RevokeFilePublicURL disables public/external sharing for a file
+// RevokeFilePublicURL disables public/external sharing for a file.
+// For more details, see RevokeFilePublicURLContext documentation.
 func (api *Client) RevokeFilePublicURL(fileID string) (*File, error) {
 	return api.RevokeFilePublicURLContext(context.Background(), fileID)
 }
 
-// RevokeFilePublicURLContext disables public/external sharing for a file with a custom context
+// RevokeFilePublicURLContext disables public/external sharing for a file with a custom context.
+// Slack API docs: https://api.slack.com/methods/files.revokePublicURL
 func (api *Client) RevokeFilePublicURLContext(ctx context.Context, fileID string) (*File, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -451,12 +474,14 @@ func (api *Client) RevokeFilePublicURLContext(ctx context.Context, fileID string
 	return &response.File, nil
 }
 
-// ShareFilePublicURL enabled public/external sharing for a file
+// ShareFilePublicURL enabled public/external sharing for a file.
+// For more details, see ShareFilePublicURLContext documentation.
 func (api *Client) ShareFilePublicURL(fileID string) (*File, []Comment, *Paging, error) {
 	return api.ShareFilePublicURLContext(context.Background(), fileID)
 }
 
-// ShareFilePublicURLContext enabled public/external sharing for a file with a custom context
+// ShareFilePublicURLContext enabled public/external sharing for a file with a custom context.
+// Slack API docs: https://api.slack.com/methods/files.sharedPublicURL
 func (api *Client) ShareFilePublicURLContext(ctx context.Context, fileID string) (*File, []Comment, *Paging, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -470,7 +495,7 @@ func (api *Client) ShareFilePublicURLContext(ctx context.Context, fileID string)
 	return &response.File, response.Comments, &response.Paging, nil
 }
 
-// getUploadURLExternal gets a URL and fileID from slack which can later be used to upload a file
+// getUploadURLExternal gets a URL and fileID from slack which can later be used to upload a file.
 func (api *Client) getUploadURLExternal(ctx context.Context, params getUploadURLExternalParameters) (*getUploadURLExternalResponse, error) {
 	values := url.Values{
 		"token":    {api.token},
@@ -496,9 +521,8 @@ func (api *Client) getUploadURLExternal(ctx context.Context, params getUploadURL
 func (api *Client) uploadToURL(ctx context.Context, params uploadToURLParameters) (err error) {
 	values := url.Values{}
 	if params.Content != "" {
-		values.Add("content", params.Content)
-		values.Add("token", api.token)
-		err = postForm(ctx, api.httpclient, params.UploadURL, values, nil, api)
+		contentReader := strings.NewReader(params.Content)
+		err = postWithMultipartResponse(ctx, api.httpclient, params.UploadURL, params.Filename, "file", api.token, values, contentReader, nil, api)
 	} else if params.File != "" {
 		err = postLocalWithMultipartResponse(ctx, api.httpclient, params.UploadURL, params.File, "file", api.token, values, nil, api)
 	} else if params.Reader != nil {
@@ -515,11 +539,13 @@ func (api *Client) completeUploadExternal(ctx context.Context, fileID string, pa
 		return nil, err
 	}
 	values := url.Values{
-		"token":      {api.token},
-		"files":      {string(requestBytes)},
-		"channel_id": {params.channel},
+		"token": {api.token},
+		"files": {string(requestBytes)},
 	}
 
+	if params.channel != "" {
+		values.Add("channel_id", params.channel)
+	}
 	if params.initialComment != "" {
 		values.Add("initial_comment", params.initialComment)
 	}
@@ -537,18 +563,18 @@ func (api *Client) completeUploadExternal(ctx context.Context, fileID string, pa
 	return response, nil
 }
 
-// UploadFileV2 uploads file to a given slack channel using 3 steps -
-//  1. Get an upload URL using files.getUploadURLExternal API
-//  2. Send the file as a post to the URL provided by slack
-//  3. Complete the upload and share it to the specified channel using files.completeUploadExternal
+// UploadFileV2 uploads file to a given slack channel using 3 steps.
+// For more details, see UploadFileV2Context documentation.
 func (api *Client) UploadFileV2(params UploadFileV2Parameters) (*FileSummary, error) {
 	return api.UploadFileV2Context(context.Background(), params)
 }
 
-// UploadFileV2 uploads file to a given slack channel using 3 steps with a custom context -
+// UploadFileV2Context uploads file to a given slack channel using 3 steps -
 //  1. Get an upload URL using files.getUploadURLExternal API
 //  2. Send the file as a post to the URL provided by slack
 //  3. Complete the upload and share it to the specified channel using files.completeUploadExternal
+//
+// Slack Docs: https://api.slack.com/messaging/files#uploading_files
 func (api *Client) UploadFileV2Context(ctx context.Context, params UploadFileV2Parameters) (file *FileSummary, err error) {
 	if params.Filename == "" {
 		return nil, fmt.Errorf("file.upload.v2: filename cannot be empty")
@@ -556,9 +582,7 @@ func (api *Client) UploadFileV2Context(ctx context.Context, params UploadFileV2P
 	if params.FileSize == 0 {
 		return nil, fmt.Errorf("file.upload.v2: file size cannot be 0")
 	}
-	if params.Channel == "" {
-		return nil, fmt.Errorf("file.upload.v2: channel cannot be empty")
-	}
+
 	u, err := api.getUploadURLExternal(ctx, getUploadURLExternalParameters{
 		altText:     params.AltTxt,
 		fileName:    params.Filename,

--- a/vendor/github.com/slack-go/slack/function_execute.go
+++ b/vendor/github.com/slack-go/slack/function_execute.go
@@ -1,0 +1,93 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type (
+	FunctionCompleteSuccessRequest struct {
+		FunctionExecutionID string            `json:"function_execution_id"`
+		Outputs             map[string]string `json:"outputs"`
+	}
+
+	FunctionCompleteErrorRequest struct {
+		FunctionExecutionID string `json:"function_execution_id"`
+		Error               string `json:"error"`
+	}
+)
+
+type FunctionCompleteSuccessRequestOption func(opt *FunctionCompleteSuccessRequest) error
+
+func FunctionCompleteSuccessRequestOptionOutput(outputs map[string]string) FunctionCompleteSuccessRequestOption {
+	return func(opt *FunctionCompleteSuccessRequest) error {
+		if len(outputs) > 0 {
+			opt.Outputs = outputs
+		}
+		return nil
+	}
+}
+
+// FunctionCompleteSuccess indicates function is completed
+func (api *Client) FunctionCompleteSuccess(functionExecutionId string, options ...FunctionCompleteSuccessRequestOption) error {
+	return api.FunctionCompleteSuccessContext(context.Background(), functionExecutionId, options...)
+}
+
+// FunctionCompleteSuccess indicates function is completed
+func (api *Client) FunctionCompleteSuccessContext(ctx context.Context, functionExecutionId string, options ...FunctionCompleteSuccessRequestOption) error {
+	// More information: https://api.slack.com/methods/functions.completeSuccess
+	r := &FunctionCompleteSuccessRequest{
+		FunctionExecutionID: functionExecutionId,
+	}
+	for _, option := range options {
+		option(r)
+	}
+
+	endpoint := api.endpoint + "functions.completeSuccess"
+	jsonData, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	response := &SlackResponse{}
+	if err := postJSON(ctx, api.httpclient, endpoint, api.token, jsonData, response, api); err != nil {
+		return err
+	}
+
+	if !response.Ok {
+		return response.Err()
+	}
+
+	return nil
+}
+
+// FunctionCompleteError indicates function is completed with error
+func (api *Client) FunctionCompleteError(functionExecutionID string, errorMessage string) error {
+	return api.FunctionCompleteErrorContext(context.Background(), functionExecutionID, errorMessage)
+}
+
+// FunctionCompleteErrorContext indicates function is completed with error
+func (api *Client) FunctionCompleteErrorContext(ctx context.Context, functionExecutionID string, errorMessage string) error {
+	// More information: https://api.slack.com/methods/functions.completeError
+	r := FunctionCompleteErrorRequest{
+		FunctionExecutionID: functionExecutionID,
+	}
+	r.Error = errorMessage
+
+	endpoint := api.endpoint + "functions.completeError"
+	jsonData, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	response := &SlackResponse{}
+	if err := postJSON(ctx, api.httpclient, endpoint, api.token, jsonData, response, api); err != nil {
+		return err
+	}
+
+	if !response.Ok {
+		return response.Err()
+	}
+
+	return nil
+}

--- a/vendor/github.com/slack-go/slack/interactions.go
+++ b/vendor/github.com/slack-go/slack/interactions.go
@@ -33,29 +33,30 @@ const (
 
 // InteractionCallback is sent from slack when a user interactions with a button or dialog.
 type InteractionCallback struct {
-	Type            InteractionType         `json:"type"`
-	Token           string                  `json:"token"`
-	CallbackID      string                  `json:"callback_id"`
-	ResponseURL     string                  `json:"response_url"`
-	TriggerID       string                  `json:"trigger_id"`
-	ActionTs        string                  `json:"action_ts"`
-	Team            Team                    `json:"team"`
-	Channel         Channel                 `json:"channel"`
-	User            User                    `json:"user"`
-	OriginalMessage Message                 `json:"original_message"`
-	Message         Message                 `json:"message"`
-	Name            string                  `json:"name"`
-	Value           string                  `json:"value"`
-	MessageTs       string                  `json:"message_ts"`
-	AttachmentID    string                  `json:"attachment_id"`
-	ActionCallback  ActionCallbacks         `json:"actions"`
-	View            View                    `json:"view"`
-	ActionID        string                  `json:"action_id"`
-	APIAppID        string                  `json:"api_app_id"`
-	BlockID         string                  `json:"block_id"`
-	Container       Container               `json:"container"`
-	Enterprise      Enterprise              `json:"enterprise"`
-	WorkflowStep    InteractionWorkflowStep `json:"workflow_step"`
+	Type                InteractionType         `json:"type"`
+	Token               string                  `json:"token"`
+	CallbackID          string                  `json:"callback_id"`
+	ResponseURL         string                  `json:"response_url"`
+	TriggerID           string                  `json:"trigger_id"`
+	ActionTs            string                  `json:"action_ts"`
+	Team                Team                    `json:"team"`
+	Channel             Channel                 `json:"channel"`
+	User                User                    `json:"user"`
+	OriginalMessage     Message                 `json:"original_message"`
+	Message             Message                 `json:"message"`
+	Name                string                  `json:"name"`
+	Value               string                  `json:"value"`
+	MessageTs           string                  `json:"message_ts"`
+	AttachmentID        string                  `json:"attachment_id"`
+	ActionCallback      ActionCallbacks         `json:"actions"`
+	View                View                    `json:"view"`
+	ActionID            string                  `json:"action_id"`
+	APIAppID            string                  `json:"api_app_id"`
+	BlockID             string                  `json:"block_id"`
+	Container           Container               `json:"container"`
+	Enterprise          Enterprise              `json:"enterprise"`
+	IsEnterpriseInstall bool                    `json:"is_enterprise_install"`
+	WorkflowStep        InteractionWorkflowStep `json:"workflow_step"`
 	DialogSubmissionCallback
 	ViewSubmissionCallback
 	ViewClosedCallback

--- a/vendor/github.com/slack-go/slack/manifests.go
+++ b/vendor/github.com/slack-go/slack/manifests.go
@@ -1,0 +1,297 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+)
+
+// Manifest is an application manifest schema
+type Manifest struct {
+	Metadata    ManifestMetadata `json:"_metadata,omitempty" yaml:"_metadata,omitempty"`
+	Display     Display          `json:"display_information" yaml:"display_information"`
+	Settings    Settings         `json:"settings,omitempty" yaml:"settings,omitempty"`
+	Features    Features         `json:"features,omitempty" yaml:"features,omitempty"`
+	OAuthConfig OAuthConfig      `json:"oauth_config,omitempty" yaml:"oauth_config,omitempty"`
+}
+
+// CreateManifest creates an app from an app manifest.
+// For more details, see CreateManifestContext documentation.
+func (api *Client) CreateManifest(manifest *Manifest, token string) (*ManifestResponse, error) {
+	return api.CreateManifestContext(context.Background(), manifest, token)
+}
+
+// CreateManifestContext creates an app from an app manifest with a custom context.
+// Slack API docs: https://api.slack.com/methods/apps.manifest.create
+func (api *Client) CreateManifestContext(ctx context.Context, manifest *Manifest, token string) (*ManifestResponse, error) {
+	if token == "" {
+		token = api.configToken
+	}
+
+	jsonBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	values := url.Values{
+		"token":    {token},
+		"manifest": {string(jsonBytes)},
+	}
+
+	response := &ManifestResponse{}
+	err = api.postMethod(ctx, "apps.manifest.create", values, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, response.Err()
+}
+
+// DeleteManifest permanently deletes an app created through app manifests.
+// For more details, see DeleteManifestContext documentation.
+func (api *Client) DeleteManifest(token string, appId string) (*SlackResponse, error) {
+	return api.DeleteManifestContext(context.Background(), token, appId)
+}
+
+// DeleteManifestContext permanently deletes an app created through app manifests with a custom context.
+// Slack API docs: https://api.slack.com/methods/apps.manifest.delete
+func (api *Client) DeleteManifestContext(ctx context.Context, token string, appId string) (*SlackResponse, error) {
+	if token == "" {
+		token = api.configToken
+	}
+
+	values := url.Values{
+		"token":  {token},
+		"app_id": {appId},
+	}
+
+	response := &SlackResponse{}
+	err := api.postMethod(ctx, "apps.manifest.delete", values, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, response.Err()
+}
+
+// ExportManifest exports an app manifest from an existing app.
+// For more details, see ExportManifestContext documentation.
+func (api *Client) ExportManifest(token string, appId string) (*Manifest, error) {
+	return api.ExportManifestContext(context.Background(), token, appId)
+}
+
+// ExportManifestContext exports an app manifest from an existing app with a custom context.
+// Slack API docs: https://api.slack.com/methods/apps.manifest.export
+func (api *Client) ExportManifestContext(ctx context.Context, token string, appId string) (*Manifest, error) {
+	if token == "" {
+		token = api.configToken
+	}
+
+	values := url.Values{
+		"token":  {token},
+		"app_id": {appId},
+	}
+
+	response := &ExportManifestResponse{}
+	err := api.postMethod(ctx, "apps.manifest.export", values, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.Manifest, response.Err()
+}
+
+// UpdateManifest updates an app from an app manifest.
+// For more details, see UpdateManifestContext documentation.
+func (api *Client) UpdateManifest(manifest *Manifest, token string, appId string) (*UpdateManifestResponse, error) {
+	return api.UpdateManifestContext(context.Background(), manifest, token, appId)
+}
+
+// UpdateManifestContext updates an app from an app manifest with a custom context.
+// Slack API docs: https://api.slack.com/methods/apps.manifest.update
+func (api *Client) UpdateManifestContext(ctx context.Context, manifest *Manifest, token string, appId string) (*UpdateManifestResponse, error) {
+	if token == "" {
+		token = api.configToken
+	}
+
+	jsonBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	values := url.Values{
+		"token":    {token},
+		"app_id":   {appId},
+		"manifest": {string(jsonBytes)},
+	}
+
+	response := &UpdateManifestResponse{}
+	err = api.postMethod(ctx, "apps.manifest.update", values, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, response.Err()
+}
+
+// ValidateManifest sends a request to apps.manifest.validate to validate your app manifest.
+// For more details, see ValidateManifestContext documentation.
+func (api *Client) ValidateManifest(manifest *Manifest, token string, appId string) (*ManifestResponse, error) {
+	return api.ValidateManifestContext(context.Background(), manifest, token, appId)
+}
+
+// ValidateManifestContext sends a request to apps.manifest.validate to validate your app manifest with a custom context.
+// Slack API docs: https://api.slack.com/methods/apps.manifest.validate
+func (api *Client) ValidateManifestContext(ctx context.Context, manifest *Manifest, token string, appId string) (*ManifestResponse, error) {
+	if token == "" {
+		token = api.configToken
+	}
+
+	// Marshal manifest into string
+	jsonBytes, err := json.Marshal(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	values := url.Values{
+		"token":    {token},
+		"manifest": {string(jsonBytes)},
+	}
+
+	if appId != "" {
+		values.Add("app_id", appId)
+	}
+
+	response := &ManifestResponse{}
+	err = api.postMethod(ctx, "apps.manifest.validate", values, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, response.Err()
+}
+
+// ManifestMetadata is a group of settings that describe the manifest
+type ManifestMetadata struct {
+	MajorVersion int `json:"major_version,omitempty" yaml:"major_version,omitempty"`
+	MinorVersion int `json:"minor_version,omitempty" yaml:"minor_version,omitempty"`
+}
+
+// Display is a group of settings that describe parts of an app's appearance within Slack
+type Display struct {
+	Name            string `json:"name" yaml:"name"`
+	Description     string `json:"description,omitempty" yaml:"description,omitempty"`
+	LongDescription string `json:"long_description,omitempty" yaml:"long_description,omitempty"`
+	BackgroundColor string `json:"background_color,omitempty" yaml:"background_color,omitempty"`
+}
+
+// Settings is a group of settings corresponding to the Settings section of the app config pages.
+type Settings struct {
+	AllowedIPAddressRanges []string           `json:"allowed_ip_address_ranges,omitempty" yaml:"allowed_ip_address_ranges,omitempty"`
+	EventSubscriptions     EventSubscriptions `json:"event_subscriptions,omitempty" yaml:"event_subscriptions,omitempty"`
+	Interactivity          Interactivity      `json:"interactivity,omitempty" yaml:"interactivity,omitempty"`
+	OrgDeployEnabled       bool               `json:"org_deploy_enabled,omitempty" yaml:"org_deploy_enabled,omitempty"`
+	SocketModeEnabled      bool               `json:"socket_mode_enabled,omitempty" yaml:"socket_mode_enabled,omitempty"`
+}
+
+// EventSubscriptions is a group of settings that describe the Events API configuration
+type EventSubscriptions struct {
+	RequestUrl string   `json:"request_url,omitempty" yaml:"request_url,omitempty"`
+	BotEvents  []string `json:"bot_events,omitempty" yaml:"bot_events,omitempty"`
+	UserEvents []string `json:"user_events,omitempty" yaml:"user_events,omitempty"`
+}
+
+// Interactivity is a group of settings that describe the interactivity configuration
+type Interactivity struct {
+	IsEnabled             bool   `json:"is_enabled" yaml:"is_enabled"`
+	RequestUrl            string `json:"request_url,omitempty" yaml:"request_url,omitempty"`
+	MessageMenuOptionsUrl string `json:"message_menu_options_url,omitempty" yaml:"message_menu_options_url,omitempty"`
+}
+
+// Features is a group of settings corresponding to the Features section of the app config pages
+type Features struct {
+	AppHome       AppHome                `json:"app_home,omitempty" yaml:"app_home,omitempty"`
+	BotUser       BotUser                `json:"bot_user,omitempty" yaml:"bot_user,omitempty"`
+	Shortcuts     []Shortcut             `json:"shortcuts,omitempty" yaml:"shortcuts,omitempty"`
+	SlashCommands []ManifestSlashCommand `json:"slash_commands,omitempty" yaml:"slash_commands,omitempty"`
+	WorkflowSteps []WorkflowStep         `json:"workflow_steps,omitempty" yaml:"workflow_steps,omitempty"`
+}
+
+// AppHome is a group of settings that describe the App Home configuration
+type AppHome struct {
+	HomeTabEnabled             bool `json:"home_tab_enabled,omitempty" yaml:"home_tab_enabled,omitempty"`
+	MessagesTabEnabled         bool `json:"messages_tab_enabled,omitempty" yaml:"messages_tab_enabled,omitempty"`
+	MessagesTabReadOnlyEnabled bool `json:"messages_tab_read_only_enabled,omitempty" yaml:"messages_tab_read_only_enabled,omitempty"`
+}
+
+// BotUser is a group of settings that describe bot user configuration
+type BotUser struct {
+	DisplayName  string `json:"display_name" yaml:"display_name"`
+	AlwaysOnline bool   `json:"always_online,omitempty" yaml:"always_online,omitempty"`
+}
+
+// Shortcut is a group of settings that describes shortcut configuration
+type Shortcut struct {
+	Name        string       `json:"name" yaml:"name"`
+	CallbackID  string       `json:"callback_id" yaml:"callback_id"`
+	Description string       `json:"description" yaml:"description"`
+	Type        ShortcutType `json:"type" yaml:"type"`
+}
+
+// ShortcutType is a new string type for the available types of shortcuts
+type ShortcutType string
+
+const (
+	MessageShortcut ShortcutType = "message"
+	GlobalShortcut  ShortcutType = "global"
+)
+
+// ManifestSlashCommand is a group of settings that describes slash command configuration
+type ManifestSlashCommand struct {
+	Command      string `json:"command" yaml:"command"`
+	Description  string `json:"description" yaml:"description"`
+	ShouldEscape bool   `json:"should_escape,omitempty" yaml:"should_escape,omitempty"`
+	Url          string `json:"url,omitempty" yaml:"url,omitempty"`
+	UsageHint    string `json:"usage_hint,omitempty" yaml:"usage_hint,omitempty"`
+}
+
+// WorkflowStep is a group of settings that describes workflow steps configuration
+type WorkflowStep struct {
+	Name       string `json:"name" yaml:"name"`
+	CallbackID string `json:"callback_id" yaml:"callback_id"`
+}
+
+// OAuthConfig is a group of settings that describe OAuth configuration for the app
+type OAuthConfig struct {
+	RedirectUrls []string    `json:"redirect_urls,omitempty" yaml:"redirect_urls,omitempty"`
+	Scopes       OAuthScopes `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+}
+
+// OAuthScopes is a group of settings that describe permission scopes configuration
+type OAuthScopes struct {
+	Bot  []string `json:"bot,omitempty" yaml:"bot,omitempty"`
+	User []string `json:"user,omitempty" yaml:"user,omitempty"`
+}
+
+// ManifestResponse is the response returned by the API for apps.manifest.x endpoints
+type ManifestResponse struct {
+	Errors []ManifestValidationError `json:"errors,omitempty"`
+	SlackResponse
+}
+
+// ManifestValidationError is an error message returned for invalid manifests
+type ManifestValidationError struct {
+	Message string `json:"message"`
+	Pointer string `json:"pointer"`
+}
+
+type ExportManifestResponse struct {
+	Manifest Manifest `json:"manifest,omitempty"`
+	SlackResponse
+}
+
+type UpdateManifestResponse struct {
+	AppId              string `json:"app_id,omitempty"`
+	PermissionsUpdated bool   `json:"permissions_updated,omitempty"`
+	ManifestResponse
+}

--- a/vendor/github.com/slack-go/slack/messages.go
+++ b/vendor/github.com/slack-go/slack/messages.go
@@ -100,10 +100,11 @@ type Msg struct {
 	Members []string `json:"members,omitempty"`
 
 	// channels.replies, groups.replies, im.replies, mpim.replies
-	ReplyCount   int     `json:"reply_count,omitempty"`
-	Replies      []Reply `json:"replies,omitempty"`
-	ParentUserId string  `json:"parent_user_id,omitempty"`
-	LatestReply  string  `json:"latest_reply,omitempty"`
+	ReplyCount   int      `json:"reply_count,omitempty"`
+	ReplyUsers   []string `json:"reply_users,omitempty"`
+	Replies      []Reply  `json:"replies,omitempty"`
+	ParentUserId string   `json:"parent_user_id,omitempty"`
+	LatestReply  string   `json:"latest_reply,omitempty"`
 
 	// file_share, file_comment, file_mention
 	Files []File `json:"files,omitempty"`

--- a/vendor/github.com/slack-go/slack/oauth.go
+++ b/vendor/github.com/slack-go/slack/oauth.go
@@ -33,17 +33,18 @@ type OAuthResponse struct {
 
 // OAuthV2Response ...
 type OAuthV2Response struct {
-	AccessToken     string                       `json:"access_token"`
-	TokenType       string                       `json:"token_type"`
-	Scope           string                       `json:"scope"`
-	BotUserID       string                       `json:"bot_user_id"`
-	AppID           string                       `json:"app_id"`
-	Team            OAuthV2ResponseTeam          `json:"team"`
-	IncomingWebhook OAuthResponseIncomingWebhook `json:"incoming_webhook"`
-	Enterprise      OAuthV2ResponseEnterprise    `json:"enterprise"`
-	AuthedUser      OAuthV2ResponseAuthedUser    `json:"authed_user"`
-	RefreshToken    string                       `json:"refresh_token"`
-	ExpiresIn       int                          `json:"expires_in"`
+	AccessToken         string                       `json:"access_token"`
+	TokenType           string                       `json:"token_type"`
+	Scope               string                       `json:"scope"`
+	BotUserID           string                       `json:"bot_user_id"`
+	AppID               string                       `json:"app_id"`
+	Team                OAuthV2ResponseTeam          `json:"team"`
+	IncomingWebhook     OAuthResponseIncomingWebhook `json:"incoming_webhook"`
+	Enterprise          OAuthV2ResponseEnterprise    `json:"enterprise"`
+	IsEnterpriseInstall bool                         `json:"is_enterprise_install"`
+	AuthedUser          OAuthV2ResponseAuthedUser    `json:"authed_user"`
+	RefreshToken        string                       `json:"refresh_token"`
+	ExpiresIn           int                          `json:"expires_in"`
 	SlackResponse
 }
 
@@ -69,12 +70,23 @@ type OAuthV2ResponseAuthedUser struct {
 	TokenType    string `json:"token_type"`
 }
 
-// GetOAuthToken retrieves an AccessToken
+// OpenIDConnectResponse ...
+type OpenIDConnectResponse struct {
+	Ok          bool   `json:"ok"`
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	IdToken     string `json:"id_token"`
+	SlackResponse
+}
+
+// GetOAuthToken retrieves an AccessToken.
+// For more details, see GetOAuthTokenContext documentation.
 func GetOAuthToken(client httpClient, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, err error) {
 	return GetOAuthTokenContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
 }
 
-// GetOAuthTokenContext retrieves an AccessToken with a custom context
+// GetOAuthTokenContext retrieves an AccessToken with a custom context.
+// For more details, see GetOAuthResponseContext documentation.
 func GetOAuthTokenContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, err error) {
 	response, err := GetOAuthResponseContext(ctx, client, clientID, clientSecret, code, redirectURI)
 	if err != nil {
@@ -84,11 +96,13 @@ func GetOAuthTokenContext(ctx context.Context, client httpClient, clientID, clie
 }
 
 // GetBotOAuthToken retrieves top-level and bot AccessToken - https://api.slack.com/legacy/oauth#bot_user_access_tokens
+// For more details, see GetBotOAuthTokenContext documentation.
 func GetBotOAuthToken(client httpClient, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, bot OAuthResponseBot, err error) {
 	return GetBotOAuthTokenContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
 }
 
-// GetBotOAuthTokenContext retrieves top-level and bot AccessToken with a custom context
+// GetBotOAuthTokenContext retrieves top-level and bot AccessToken with a custom context.
+// For more details, see GetOAuthResponseContext documentation.
 func GetBotOAuthTokenContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (accessToken string, scope string, bot OAuthResponseBot, err error) {
 	response, err := GetOAuthResponseContext(ctx, client, clientID, clientSecret, code, redirectURI)
 	if err != nil {
@@ -97,12 +111,14 @@ func GetBotOAuthTokenContext(ctx context.Context, client httpClient, clientID, c
 	return response.AccessToken, response.Scope, response.Bot, nil
 }
 
-// GetOAuthResponse retrieves OAuth response
+// GetOAuthResponse retrieves OAuth response.
+// For more details, see GetOAuthResponseContext documentation.
 func GetOAuthResponse(client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthResponse, err error) {
 	return GetOAuthResponseContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
 }
 
-// GetOAuthResponseContext retrieves OAuth response with custom context
+// GetOAuthResponseContext retrieves OAuth response with custom context.
+// Slack API docs: https://api.slack.com/methods/oauth.access
 func GetOAuthResponseContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthResponse, err error) {
 	values := url.Values{
 		"client_id":     {clientID},
@@ -117,12 +133,14 @@ func GetOAuthResponseContext(ctx context.Context, client httpClient, clientID, c
 	return response, response.Err()
 }
 
-// GetOAuthV2Response gets a V2 OAuth access token response - https://api.slack.com/methods/oauth.v2.access
+// GetOAuthV2Response gets a V2 OAuth access token response.
+// For more details, see GetOAuthV2ResponseContext documentation.
 func GetOAuthV2Response(client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthV2Response, err error) {
 	return GetOAuthV2ResponseContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
 }
 
-// GetOAuthV2ResponseContext with a context, gets a V2 OAuth access token response
+// GetOAuthV2ResponseContext with a context, gets a V2 OAuth access token response.
+// Slack API docs: https://api.slack.com/methods/oauth.v2.access
 func GetOAuthV2ResponseContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OAuthV2Response, err error) {
 	values := url.Values{
 		"client_id":     {clientID},
@@ -137,12 +155,14 @@ func GetOAuthV2ResponseContext(ctx context.Context, client httpClient, clientID,
 	return response, response.Err()
 }
 
-// RefreshOAuthV2AccessContext with a context, gets a V2 OAuth access token response
+// RefreshOAuthV2Token with a context, gets a V2 OAuth access token response.
+// For more details, see RefreshOAuthV2TokenContext documentation.
 func RefreshOAuthV2Token(client httpClient, clientID, clientSecret, refreshToken string) (resp *OAuthV2Response, err error) {
 	return RefreshOAuthV2TokenContext(context.Background(), client, clientID, clientSecret, refreshToken)
 }
 
-// RefreshOAuthV2AccessContext with a context, gets a V2 OAuth access token response
+// RefreshOAuthV2TokenContext with a context, gets a V2 OAuth access token response.
+// Slack API docs: https://api.slack.com/methods/oauth.v2.access
 func RefreshOAuthV2TokenContext(ctx context.Context, client httpClient, clientID, clientSecret, refreshToken string) (resp *OAuthV2Response, err error) {
 	values := url.Values{
 		"client_id":     {clientID},
@@ -152,6 +172,28 @@ func RefreshOAuthV2TokenContext(ctx context.Context, client httpClient, clientID
 	}
 	response := &OAuthV2Response{}
 	if err = postForm(ctx, client, APIURL+"oauth.v2.access", values, response, discard{}); err != nil {
+		return nil, err
+	}
+	return response, response.Err()
+}
+
+// GetOpenIDConnectToken exchanges a temporary OAuth verifier code for an access token for Sign in with Slack.
+// For more details, see GetOpenIDConnectTokenContext documentation.
+func GetOpenIDConnectToken(client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OpenIDConnectResponse, err error) {
+	return GetOpenIDConnectTokenContext(context.Background(), client, clientID, clientSecret, code, redirectURI)
+}
+
+// GetOpenIDConnectTokenContext with a context, gets an access token for Sign in with Slack.
+// Slack API docs: https://api.slack.com/methods/openid.connect.token
+func GetOpenIDConnectTokenContext(ctx context.Context, client httpClient, clientID, clientSecret, code, redirectURI string) (resp *OpenIDConnectResponse, err error) {
+	values := url.Values{
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+	}
+	response := &OpenIDConnectResponse{}
+	if err = postForm(ctx, client, APIURL+"openid.connect.token", values, response, discard{}); err != nil {
 		return nil, err
 	}
 	return response, response.Err()

--- a/vendor/github.com/slack-go/slack/pins.go
+++ b/vendor/github.com/slack-go/slack/pins.go
@@ -12,12 +12,14 @@ type listPinsResponseFull struct {
 	SlackResponse
 }
 
-// AddPin pins an item in a channel
+// AddPin pins an item in a channel.
+// For more details, see AddPinContext documentation.
 func (api *Client) AddPin(channel string, item ItemRef) error {
 	return api.AddPinContext(context.Background(), channel, item)
 }
 
-// AddPinContext pins an item in a channel with a custom context
+// AddPinContext pins an item in a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/pins.add
 func (api *Client) AddPinContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
@@ -41,12 +43,14 @@ func (api *Client) AddPinContext(ctx context.Context, channel string, item ItemR
 	return response.Err()
 }
 
-// RemovePin un-pins an item from a channel
+// RemovePin un-pins an item from a channel.
+// For more details, see RemovePinContext documentation.
 func (api *Client) RemovePin(channel string, item ItemRef) error {
 	return api.RemovePinContext(context.Background(), channel, item)
 }
 
-// RemovePinContext un-pins an item from a channel with a custom context
+// RemovePinContext un-pins an item from a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/pins.remove
 func (api *Client) RemovePinContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
@@ -71,11 +75,13 @@ func (api *Client) RemovePinContext(ctx context.Context, channel string, item It
 }
 
 // ListPins returns information about the items a user reacted to.
+// For more details, see ListPinsContext documentation.
 func (api *Client) ListPins(channel string) ([]Item, *Paging, error) {
 	return api.ListPinsContext(context.Background(), channel)
 }
 
 // ListPinsContext returns information about the items a user reacted to with a custom context.
+// Slack API docs: https://api.slack.com/methods/pins.list
 func (api *Client) ListPinsContext(ctx context.Context, channel string) ([]Item, *Paging, error) {
 	values := url.Values{
 		"channel": {channel},

--- a/vendor/github.com/slack-go/slack/reactions.go
+++ b/vendor/github.com/slack-go/slack/reactions.go
@@ -67,10 +67,11 @@ const (
 
 // ListReactionsParameters is the inputs to find all reactions by a user.
 type ListReactionsParameters struct {
-	User  string
-	Count int
-	Page  int
-	Full  bool
+	User   string
+	TeamID string
+	Count  int
+	Page   int
+	Full   bool
 }
 
 // NewListReactionsParameters initializes the inputs to find all reactions
@@ -128,11 +129,13 @@ func (res listReactionsResponseFull) extractReactedItems() []ReactedItem {
 }
 
 // AddReaction adds a reaction emoji to a message, file or file comment.
+// For more details, see AddReactionContext documentation.
 func (api *Client) AddReaction(name string, item ItemRef) error {
 	return api.AddReactionContext(context.Background(), name, item)
 }
 
 // AddReactionContext adds a reaction emoji to a message, file or file comment with a custom context.
+// Slack API docs: https://api.slack.com/methods/reactions.add
 func (api *Client) AddReactionContext(ctx context.Context, name string, item ItemRef) error {
 	values := url.Values{
 		"token": {api.token},
@@ -162,11 +165,13 @@ func (api *Client) AddReactionContext(ctx context.Context, name string, item Ite
 }
 
 // RemoveReaction removes a reaction emoji from a message, file or file comment.
+// For more details, see RemoveReactionContext documentation.
 func (api *Client) RemoveReaction(name string, item ItemRef) error {
 	return api.RemoveReactionContext(context.Background(), name, item)
 }
 
 // RemoveReactionContext removes a reaction emoji from a message, file or file comment with a custom context.
+// Slack API docs: https://api.slack.com/methods/reactions.remove
 func (api *Client) RemoveReactionContext(ctx context.Context, name string, item ItemRef) error {
 	values := url.Values{
 		"token": {api.token},
@@ -196,11 +201,13 @@ func (api *Client) RemoveReactionContext(ctx context.Context, name string, item 
 }
 
 // GetReactions returns details about the reactions on an item.
+// For more details, see GetReactionsContext documentation.
 func (api *Client) GetReactions(item ItemRef, params GetReactionsParameters) ([]ItemReaction, error) {
 	return api.GetReactionsContext(context.Background(), item, params)
 }
 
-// GetReactionsContext returns details about the reactions on an item with a custom context
+// GetReactionsContext returns details about the reactions on an item with a custom context.
+// Slack API docs: https://api.slack.com/methods/reactions.get
 func (api *Client) GetReactionsContext(ctx context.Context, item ItemRef, params GetReactionsParameters) ([]ItemReaction, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -234,17 +241,22 @@ func (api *Client) GetReactionsContext(ctx context.Context, item ItemRef, params
 }
 
 // ListReactions returns information about the items a user reacted to.
+// For more details, see ListReactionsContext documentation.
 func (api *Client) ListReactions(params ListReactionsParameters) ([]ReactedItem, *Paging, error) {
 	return api.ListReactionsContext(context.Background(), params)
 }
 
 // ListReactionsContext returns information about the items a user reacted to with a custom context.
+// Slack API docs: https://api.slack.com/methods/reactions.list
 func (api *Client) ListReactionsContext(ctx context.Context, params ListReactionsParameters) ([]ReactedItem, *Paging, error) {
 	values := url.Values{
 		"token": {api.token},
 	}
 	if params.User != DEFAULT_REACTIONS_USER {
 		values.Add("user", params.User)
+	}
+	if params.TeamID != "" {
+		values.Add("team_id", params.TeamID)
 	}
 	if params.Count != DEFAULT_REACTIONS_COUNT {
 		values.Add("count", strconv.Itoa(params.Count))

--- a/vendor/github.com/slack-go/slack/reminders.go
+++ b/vendor/github.com/slack-go/slack/reminders.go
@@ -41,23 +41,18 @@ func (api *Client) doReminders(ctx context.Context, path string, values url.Valu
 
 	// create an array of pointers to reminders
 	var reminders = make([]*Reminder, 0, len(response.Reminders))
-	for _, reminder := range response.Reminders {
-		reminders = append(reminders, reminder)
-	}
-
+	reminders = append(reminders, response.Reminders...)
 	return reminders, response.Err()
 }
 
 // ListReminders lists all the reminders created by or for the authenticated user
-//
-// See https://api.slack.com/methods/reminders.list
+// For more details, see ListRemindersContext documentation.
 func (api *Client) ListReminders() ([]*Reminder, error) {
 	return api.ListRemindersContext(context.Background())
 }
 
-// ListRemindersContext lists all the reminders created by or for the authenticated user with a custom context
-//
-// For more details, see ListReminders documentation.
+// ListRemindersContext lists all the reminders created by or for the authenticated user with a custom context.
+// Slack API docs: https://api.slack.com/methods/reminders.list
 func (api *Client) ListRemindersContext(ctx context.Context) ([]*Reminder, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -66,17 +61,14 @@ func (api *Client) ListRemindersContext(ctx context.Context) ([]*Reminder, error
 }
 
 // AddChannelReminder adds a reminder for a channel.
-//
-// See https://api.slack.com/methods/reminders.add (NOTE: the ability to set
-// reminders on a channel is currently undocumented but has been tested to
-// work)
+// For more details, see AddChannelReminderContext documentation.
 func (api *Client) AddChannelReminder(channelID, text, time string) (*Reminder, error) {
 	return api.AddChannelReminderContext(context.Background(), channelID, text, time)
 }
 
 // AddChannelReminderContext adds a reminder for a channel with a custom context
-//
-// For more details, see AddChannelReminder documentation.
+// NOTE: the ability to set reminders on a channel is currently undocumented but has been tested to work.
+// Slack API docs: https://api.slack.com/methods/reminders.add
 func (api *Client) AddChannelReminderContext(ctx context.Context, channelID, text, time string) (*Reminder, error) {
 	values := url.Values{
 		"token":   {api.token},
@@ -88,17 +80,13 @@ func (api *Client) AddChannelReminderContext(ctx context.Context, channelID, tex
 }
 
 // AddUserReminder adds a reminder for a user.
-//
-// See https://api.slack.com/methods/reminders.add (NOTE: the ability to set
-// reminders on a channel is currently undocumented but has been tested to
-// work)
+// For more details, see AddUserReminderContext documentation.
 func (api *Client) AddUserReminder(userID, text, time string) (*Reminder, error) {
 	return api.AddUserReminderContext(context.Background(), userID, text, time)
 }
 
 // AddUserReminderContext adds a reminder for a user with a custom context
-//
-// For more details, see AddUserReminder documentation.
+// Slack API docs: https://api.slack.com/methods/reminders.add
 func (api *Client) AddUserReminderContext(ctx context.Context, userID, text, time string) (*Reminder, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -110,15 +98,13 @@ func (api *Client) AddUserReminderContext(ctx context.Context, userID, text, tim
 }
 
 // DeleteReminder deletes an existing reminder.
-//
-// See https://api.slack.com/methods/reminders.delete
+// For more details, see DeleteReminderContext documentation.
 func (api *Client) DeleteReminder(id string) error {
 	return api.DeleteReminderContext(context.Background(), id)
 }
 
 // DeleteReminderContext deletes an existing reminder with a custom context
-//
-// For more details, see DeleteReminder documentation.
+// Slack API docs: https://api.slack.com/methods/reminders.delete
 func (api *Client) DeleteReminderContext(ctx context.Context, id string) error {
 	values := url.Values{
 		"token":    {api.token},

--- a/vendor/github.com/slack-go/slack/remotefiles.go
+++ b/vendor/github.com/slack-go/slack/remotefiles.go
@@ -97,14 +97,13 @@ func (api *Client) remoteFileRequest(ctx context.Context, path string, values ur
 }
 
 // AddRemoteFile adds a remote file. Unlike regular files, remote files must be explicitly shared.
-// For more details:
-// https://api.slack.com/methods/files.remote.add
+// For more details see the AddRemoteFileContext documentation.
 func (api *Client) AddRemoteFile(params RemoteFileParameters) (*RemoteFile, error) {
 	return api.AddRemoteFileContext(context.Background(), params)
 }
 
 // AddRemoteFileContext adds a remote file and setting a custom context
-// For more details see the AddRemoteFile documentation.
+// Slack API docs: https://api.slack.com/methods/files.remote.add
 func (api *Client) AddRemoteFileContext(ctx context.Context, params RemoteFileParameters) (remotefile *RemoteFile, err error) {
 	if params.ExternalID == "" || params.ExternalURL == "" || params.Title == "" {
 		return nil, ErrParametersMissing
@@ -138,14 +137,13 @@ func (api *Client) AddRemoteFileContext(ctx context.Context, params RemoteFilePa
 }
 
 // ListRemoteFiles retrieves all remote files according to the parameters given. Uses cursor based pagination.
-// For more details:
-// https://api.slack.com/methods/files.remote.list
+// For more details see the ListRemoteFilesContext documentation.
 func (api *Client) ListRemoteFiles(params ListRemoteFilesParameters) ([]RemoteFile, error) {
 	return api.ListRemoteFilesContext(context.Background(), params)
 }
 
 // ListRemoteFilesContext retrieves all remote files according to the parameters given with a custom context. Uses cursor based pagination.
-// For more details see the ListRemoteFiles documentation.
+// Slack API docs: https://api.slack.com/methods/files.remote.list
 func (api *Client) ListRemoteFilesContext(ctx context.Context, params ListRemoteFilesParameters) ([]RemoteFile, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -177,14 +175,13 @@ func (api *Client) ListRemoteFilesContext(ctx context.Context, params ListRemote
 }
 
 // GetRemoteFileInfo retrieves the complete remote file information.
-// For more details:
-// https://api.slack.com/methods/files.remote.info
+// For more details see the GetRemoteFileInfoContext documentation.
 func (api *Client) GetRemoteFileInfo(externalID, fileID string) (remotefile *RemoteFile, err error) {
 	return api.GetRemoteFileInfoContext(context.Background(), externalID, fileID)
 }
 
 // GetRemoteFileInfoContext retrieves the complete remote file information given with a custom context.
-// For more details see the GetRemoteFileInfo documentation.
+// Slack API docs: https://api.slack.com/methods/files.remote.info
 func (api *Client) GetRemoteFileInfoContext(ctx context.Context, externalID, fileID string) (remotefile *RemoteFile, err error) {
 	if fileID == "" && externalID == "" {
 		return nil, fmt.Errorf("either externalID or fileID is required")
@@ -208,15 +205,14 @@ func (api *Client) GetRemoteFileInfoContext(ctx context.Context, externalID, fil
 	return &response.RemoteFile, err
 }
 
-// ShareRemoteFile shares a remote file to channels
-// For more details:
-// https://api.slack.com/methods/files.remote.share
+// ShareRemoteFile shares a remote file to channels.
+// For more details see the ShareRemoteFileContext documentation.
 func (api *Client) ShareRemoteFile(channels []string, externalID, fileID string) (file *RemoteFile, err error) {
 	return api.ShareRemoteFileContext(context.Background(), channels, externalID, fileID)
 }
 
 // ShareRemoteFileContext shares a remote file to channels with a custom context.
-// For more details see the ShareRemoteFile documentation.
+// Slack API docs: https://api.slack.com/methods/files.remote.share
 func (api *Client) ShareRemoteFileContext(ctx context.Context, channels []string, externalID, fileID string) (file *RemoteFile, err error) {
 	if channels == nil || len(channels) == 0 {
 		return nil, ErrParametersMissing
@@ -241,20 +237,17 @@ func (api *Client) ShareRemoteFileContext(ctx context.Context, channels []string
 	return &response.RemoteFile, err
 }
 
-// UpdateRemoteFile updates a remote file
-// For more details:
-// https://api.slack.com/methods/files.remote.update
+// UpdateRemoteFile updates a remote file.
+// For more details see the UpdateRemoteFileContext documentation.
 func (api *Client) UpdateRemoteFile(fileID string, params RemoteFileParameters) (remotefile *RemoteFile, err error) {
 	return api.UpdateRemoteFileContext(context.Background(), fileID, params)
 }
 
-// UpdateRemoteFileContext updates a remote file with a custom context
-// For more details see the UpdateRemoteFile documentation.
+// UpdateRemoteFileContext updates a remote file with a custom context.
+// Slack API docs: https://api.slack.com/methods/files.remote.update
 func (api *Client) UpdateRemoteFileContext(ctx context.Context, fileID string, params RemoteFileParameters) (remotefile *RemoteFile, err error) {
 	response := &remoteFileResponseFull{}
-	values := url.Values{
-		"token": {api.token},
-	}
+	values := url.Values{}
 	if fileID != "" {
 		values.Add("file", fileID)
 	}
@@ -276,6 +269,7 @@ func (api *Client) UpdateRemoteFileContext(ctx context.Context, fileID string, p
 	if params.PreviewImageReader != nil {
 		err = postWithMultipartResponse(ctx, api.httpclient, api.endpoint+"files.remote.update", "preview.png", "preview_image", api.token, values, params.PreviewImageReader, response, api)
 	} else {
+		values.Add("token", api.token)
 		response, err = api.remoteFileRequest(ctx, "files.remote.update", values)
 	}
 
@@ -287,14 +281,13 @@ func (api *Client) UpdateRemoteFileContext(ctx context.Context, fileID string, p
 }
 
 // RemoveRemoteFile removes a remote file.
-// For more details:
-// https://api.slack.com/methods/files.remote.remove
+// For more information see the RemoveRemoteFileContext documentation.
 func (api *Client) RemoveRemoteFile(externalID, fileID string) (err error) {
 	return api.RemoveRemoteFileContext(context.Background(), externalID, fileID)
 }
 
 // RemoveRemoteFileContext removes a remote file with a custom context
-// For more information see the RemoveRemoteFiles documentation.
+// Slack API docs: https://api.slack.com/methods/files.remote.remove
 func (api *Client) RemoveRemoteFileContext(ctx context.Context, externalID, fileID string) (err error) {
 	if fileID == "" && externalID == "" {
 		return fmt.Errorf("either externalID or fileID is required")

--- a/vendor/github.com/slack-go/slack/search.go
+++ b/vendor/github.com/slack-go/slack/search.go
@@ -15,6 +15,7 @@ const (
 )
 
 type SearchParameters struct {
+	TeamID        string
 	Sort          string
 	SortDirection string
 	Highlight     bool
@@ -92,6 +93,9 @@ func (api *Client) _search(ctx context.Context, path, query string, params Searc
 	values := url.Values{
 		"token": {api.token},
 		"query": {query},
+	}
+	if params.TeamID != "" {
+		values.Add("team_id", params.TeamID)
 	}
 	if params.Sort != DEFAULT_SEARCH_SORT {
 		values.Add("sort", params.Sort)

--- a/vendor/github.com/slack-go/slack/slack.go
+++ b/vendor/github.com/slack-go/slack/slack.go
@@ -57,12 +57,14 @@ type authTestResponseFull struct {
 type ParamOption func(*url.Values)
 
 type Client struct {
-	token         string
-	appLevelToken string
-	endpoint      string
-	debug         bool
-	log           ilogger
-	httpclient    httpClient
+	token              string
+	appLevelToken      string
+	configToken        string
+	configRefreshToken string
+	endpoint           string
+	debug              bool
+	log                ilogger
+	httpclient         httpClient
 }
 
 // Option defines an option for a Client
@@ -97,6 +99,16 @@ func OptionAPIURL(u string) func(*Client) {
 // OptionAppLevelToken sets an app-level token for the client.
 func OptionAppLevelToken(token string) func(*Client) {
 	return func(c *Client) { c.appLevelToken = token }
+}
+
+// OptionConfigToken sets a configuration token for the client.
+func OptionConfigToken(token string) func(*Client) {
+	return func(c *Client) { c.configToken = token }
+}
+
+// OptionConfigRefreshToken sets a configuration refresh token for the client.
+func OptionConfigRefreshToken(token string) func(*Client) {
+	return func(c *Client) { c.configRefreshToken = token }
 }
 
 // New builds a slack client from the provided token and options.

--- a/vendor/github.com/slack-go/slack/slackevents/inner_events.go
+++ b/vendor/github.com/slack-go/slack/slackevents/inner_events.go
@@ -28,6 +28,9 @@ type AppMentionEvent struct {
 
 	// BotID is filled out when a bot triggers the app_mention event
 	BotID string `json:"bot_id,omitempty"`
+
+	// When the app is mentioned in the edited message
+	Edited *Edited `json:"edited,omitempty"`
 }
 
 // AppHomeOpenedEvent Your Slack app home was opened.
@@ -256,6 +259,9 @@ type MessageEvent struct {
 	PreviousMessage *MessageEvent `json:"previous_message,omitempty"`
 	Edited          *Edited       `json:"edited,omitempty"`
 
+	// Deleted Message
+	DeletedTimeStamp string `json:"deleted_ts,omitempty"`
+
 	// Message Subtypes
 	SubType string `json:"subtype,omitempty"`
 
@@ -267,7 +273,10 @@ type MessageEvent struct {
 	Upload bool   `json:"upload"`
 	Files  []File `json:"files"`
 
+	Blocks      slack.Blocks       `json:"blocks,omitempty"`
 	Attachments []slack.Attachment `json:"attachments,omitempty"`
+
+	Metadata slack.SlackMetadata `json:"metadata,omitempty"`
 
 	// Root is the message that was broadcast to the channel when the SubType is
 	// thread_broadcast. If this is not a thread_broadcast message event, this
@@ -456,6 +465,7 @@ type File struct {
 	DisplayAsBot       bool   `json:"display_as_bot"`
 	Username           string `json:"username"`
 	URLPrivate         string `json:"url_private"`
+	FileAccess         string `json:"file_access"`
 	URLPrivateDownload string `json:"url_private_download"`
 	Thumb64            string `json:"thumb_64"`
 	Thumb80            string `json:"thumb_80"`
@@ -536,6 +546,568 @@ type TeamAccessRevokedEvent struct {
 	TeamIDs []string `json:"team_ids"`
 }
 
+// UserProfileChangedEvent is sent if access to teams was revoked for your org-wide app.
+type UserProfileChangedEvent struct {
+	User    *slack.User `json:"user"`
+	CacheTs int         `json:"cache_ts"`
+	Type    string      `json:"type"`
+	EventTs string      `json:"event_ts"`
+}
+
+// SharedChannelInviteApprovedEvent is sent if your invitation has been approved
+type SharedChannelInviteApprovedEvent struct {
+	Type            string              `json:"type"`
+	Invite          *SharedInvite       `json:"invite"`
+	Channel         *slack.Conversation `json:"channel"`
+	ApprovingTeamID string              `json:"approving_team_id"`
+	TeamsInChannel  []*SlackEventTeam   `json:"teams_in_channel"`
+	ApprovingUser   *SlackEventUser     `json:"approving_user"`
+	EventTs         string              `json:"event_ts"`
+}
+
+// SharedChannelInviteAcceptedEvent is sent if external org accepts a Slack Connect channel invite
+type SharedChannelInviteAcceptedEvent struct {
+	Type                string            `json:"type"`
+	ApprovalRequired    bool              `json:"approval_required"`
+	Invite              *SharedInvite     `json:"invite"`
+	Channel             *SharedChannel    `json:"channel"`
+	TeamsInChannel      []*SlackEventTeam `json:"teams_in_channel"`
+	AcceptingUser       *SlackEventUser   `json:"accepting_user"`
+	EventTs             string            `json:"event_ts"`
+	RequiresSponsorship bool              `json:"requires_sponsorship,omitempty"`
+}
+
+// SharedChannelInviteDeclinedEvent is sent if external or internal org declines the Slack Connect invite
+type SharedChannelInviteDeclinedEvent struct {
+	Type            string            `json:"type"`
+	Invite          *SharedInvite     `json:"invite"`
+	Channel         *SharedChannel    `json:"channel"`
+	DecliningTeamID string            `json:"declining_team_id"`
+	TeamsInChannel  []*SlackEventTeam `json:"teams_in_channel"`
+	DecliningUser   *SlackEventUser   `json:"declining_user"`
+	EventTs         string            `json:"event_ts"`
+}
+
+// SharedChannelInviteReceivedEvent is sent if a bot or app is invited to a Slack Connect channel
+type SharedChannelInviteReceivedEvent struct {
+	Type    string         `json:"type"`
+	Invite  *SharedInvite  `json:"invite"`
+	Channel *SharedChannel `json:"channel"`
+	EventTs string         `json:"event_ts"`
+}
+
+// SlackEventTeam is a struct for teams in ShareChannel events
+type SlackEventTeam struct {
+	ID                  string          `json:"id"`
+	Name                string          `json:"name"`
+	Icon                *SlackEventIcon `json:"icon,omitempty"`
+	AvatarBaseURL       string          `json:"avatar_base_url,omitempty"`
+	IsVerified          bool            `json:"is_verified"`
+	Domain              string          `json:"domain"`
+	DateCreated         int             `json:"date_created"`
+	RequiresSponsorship bool            `json:"requires_sponsorship,omitempty"`
+	// TeamID              string          `json:"team_id,omitempty"`
+}
+
+// SlackEventIcon is a struct for icons in ShareChannel events
+type SlackEventIcon struct {
+	ImageDefault bool   `json:"image_default,omitempty"`
+	Image34      string `json:"image_34,omitempty"`
+	Image44      string `json:"image_44,omitempty"`
+	Image68      string `json:"image_68,omitempty"`
+	Image88      string `json:"image_88,omitempty"`
+	Image102     string `json:"image_102,omitempty"`
+	Image132     string `json:"image_132,omitempty"`
+	Image230     string `json:"image_230,omitempty"`
+}
+
+// SlackEventUser is a struct for users in ShareChannel events
+type SlackEventUser struct {
+	ID                     string             `json:"id"`
+	TeamID                 string             `json:"team_id"`
+	Name                   string             `json:"name"`
+	Updated                int                `json:"updated,omitempty"`
+	Profile                *slack.UserProfile `json:"profile,omitempty"`
+	WhoCanShareContactCard string             `json:"who_can_share_contact_card,omitempty"`
+}
+
+// SharedChannel is a struct for shared channels in ShareChannel events
+type SharedChannel struct {
+	ID        string `json:"id"`
+	IsPrivate bool   `json:"is_private"`
+	IsIm      bool   `json:"is_im"`
+	Name      string `json:"name,omitempty"`
+}
+
+// SharedInvite is a struct for shared invites in ShareChannel events
+type SharedInvite struct {
+	ID                string          `json:"id"`
+	DateCreated       int             `json:"date_created"`
+	DateInvalid       int             `json:"date_invalid"`
+	InvitingTeam      *SlackEventTeam `json:"inviting_team,omitempty"`
+	InvitingUser      *SlackEventUser `json:"inviting_user,omitempty"`
+	RecipientEmail    string          `json:"recipient_email,omitempty"`
+	RecipientUserID   string          `json:"recipient_user_id,omitempty"`
+	IsSponsored       bool            `json:"is_sponsored,omitempty"`
+	IsExternalLimited bool            `json:"is_external_limited,omitempty"`
+}
+
+type ChannelHistoryChangedEvent struct {
+	Type    string `json:"type"`
+	Latest  string `json:"latest"`
+	Ts      string `json:"ts"`
+	EventTs string `json:"event_ts"`
+}
+
+type CommandsChangedEvent struct {
+	Type    string `json:"type"`
+	EventTs string `json:"event_ts"`
+}
+
+type DndUpdatedEvent struct {
+	Type      string `json:"type"`
+	User      string `json:"user"`
+	DndStatus struct {
+		DndEnabled     bool  `json:"dnd_enabled"`
+		NextDndStartTs int64 `json:"next_dnd_start_ts"`
+		NextDndEndTs   int64 `json:"next_dnd_end_ts"`
+		SnoozeEnabled  bool  `json:"snooze_enabled"`
+		SnoozeEndtime  int64 `json:"snooze_endtime"`
+	} `json:"dnd_status"`
+}
+
+type DndUpdatedUserEvent struct {
+	Type      string `json:"type"`
+	User      string `json:"user"`
+	DndStatus struct {
+		DndEnabled     bool  `json:"dnd_enabled"`
+		NextDndStartTs int64 `json:"next_dnd_start_ts"`
+		NextDndEndTs   int64 `json:"next_dnd_end_ts"`
+	} `json:"dnd_status"`
+}
+
+type EmailDomainChangedEvent struct {
+	Type        string `json:"type"`
+	EmailDomain string `json:"email_domain"`
+	EventTs     string `json:"event_ts"`
+}
+
+type GroupCloseEvent struct {
+	Type    string `json:"type"`
+	User    string `json:"user"`
+	Channel string `json:"channel"`
+}
+
+type GroupHistoryChangedEvent struct {
+	Type    string `json:"type"`
+	Latest  string `json:"latest"`
+	Ts      string `json:"ts"`
+	EventTs string `json:"event_ts"`
+}
+
+type GroupOpenEvent struct {
+	Type    string `json:"type"`
+	User    string `json:"user"`
+	Channel string `json:"channel"`
+}
+
+type ImCloseEvent struct {
+	Type    string `json:"type"`
+	User    string `json:"user"`
+	Channel string `json:"channel"`
+}
+
+type ImCreatedEvent struct {
+	Type    string `json:"type"`
+	User    string `json:"user"`
+	Channel struct {
+		ID string `json:"id"`
+	} `json:"channel"`
+}
+
+type ImHistoryChangedEvent struct {
+	Type    string `json:"type"`
+	Latest  string `json:"latest"`
+	Ts      string `json:"ts"`
+	EventTs string `json:"event_ts"`
+}
+
+type ImOpenEvent struct {
+	Type    string `json:"type"`
+	User    string `json:"user"`
+	Channel string `json:"channel"`
+}
+
+type SubTeam struct {
+	ID          string `json:"id"`
+	TeamID      string `json:"team_id"`
+	IsUsergroup bool   `json:"is_usergroup"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Handle      string `json:"handle"`
+	IsExternal  bool   `json:"is_external"`
+	DateCreate  int64  `json:"date_create"`
+	DateUpdate  int64  `json:"date_update"`
+	DateDelete  int64  `json:"date_delete"`
+	AutoType    string `json:"auto_type"`
+	CreatedBy   string `json:"created_by"`
+	UpdatedBy   string `json:"updated_by"`
+	DeletedBy   string `json:"deleted_by"`
+	Prefs       struct {
+		Channels []string `json:"channels"`
+		Groups   []string `json:"groups"`
+	} `json:"prefs"`
+	Users     []string `json:"users"`
+	UserCount int      `json:"user_count"`
+}
+
+type SubteamCreatedEvent struct {
+	Type    string  `json:"type"`
+	Subteam SubTeam `json:"subteam"`
+}
+
+type SubteamMembersChangedEvent struct {
+	Type               string   `json:"type"`
+	SubteamID          string   `json:"subteam_id"`
+	TeamID             string   `json:"team_id"`
+	DatePreviousUpdate int      `json:"date_previous_update"`
+	DateUpdate         int64    `json:"date_update"`
+	AddedUsers         []string `json:"added_users"`
+	AddedUsersCount    string   `json:"added_users_count"`
+	RemovedUsers       []string `json:"removed_users"`
+	RemovedUsersCount  string   `json:"removed_users_count"`
+}
+
+type SubteamSelfAddedEvent struct {
+	Type      string `json:"type"`
+	SubteamID string `json:"subteam_id"`
+}
+
+type SubteamSelfRemovedEvent struct {
+	Type      string `json:"type"`
+	SubteamID string `json:"subteam_id"`
+}
+
+type SubteamUpdatedEvent struct {
+	Type    string  `json:"type"`
+	Subteam SubTeam `json:"subteam"`
+}
+
+type TeamDomainChangeEvent struct {
+	Type   string `json:"type"`
+	URL    string `json:"url"`
+	Domain string `json:"domain"`
+	TeamID string `json:"team_id"`
+}
+
+type TeamRenameEvent struct {
+	Type   string `json:"type"`
+	Name   string `json:"name"`
+	TeamID string `json:"team_id"`
+}
+
+type UserChangeEvent struct {
+	Type    string `json:"type"`
+	User    User   `json:"user"`
+	CacheTS int64  `json:"cache_ts"`
+	EventTS string `json:"event_ts"`
+}
+
+type AppDeletedEvent struct {
+	Type       string `json:"type"`
+	AppID      string `json:"app_id"`
+	AppName    string `json:"app_name"`
+	AppOwnerID string `json:"app_owner_id"`
+	TeamID     string `json:"team_id"`
+	TeamDomain string `json:"team_domain"`
+	EventTs    string `json:"event_ts"`
+}
+
+type AppInstalledEvent struct {
+	Type       string `json:"type"`
+	AppID      string `json:"app_id"`
+	AppName    string `json:"app_name"`
+	AppOwnerID string `json:"app_owner_id"`
+	UserID     string `json:"user_id"`
+	TeamID     string `json:"team_id"`
+	TeamDomain string `json:"team_domain"`
+	EventTs    string `json:"event_ts"`
+}
+
+type AppRequestedEvent struct {
+	Type       string `json:"type"`
+	AppRequest struct {
+		ID  string `json:"id"`
+		App struct {
+			ID                     string `json:"id"`
+			Name                   string `json:"name"`
+			Description            string `json:"description"`
+			HelpURL                string `json:"help_url"`
+			PrivacyPolicyURL       string `json:"privacy_policy_url"`
+			AppHomepageURL         string `json:"app_homepage_url"`
+			AppDirectoryURL        string `json:"app_directory_url"`
+			IsAppDirectoryApproved bool   `json:"is_app_directory_approved"`
+			IsInternal             bool   `json:"is_internal"`
+			AdditionalInfo         string `json:"additional_info"`
+		} `json:"app"`
+		PreviousResolution struct {
+			Status string `json:"status"`
+			Scopes []struct {
+				Name        string `json:"name"`
+				Description string `json:"description"`
+				IsSensitive bool   `json:"is_sensitive"`
+				TokenType   string `json:"token_type"`
+			} `json:"scopes"`
+		} `json:"previous_resolution"`
+		User struct {
+			ID    string `json:"id"`
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"user"`
+		Team struct {
+			ID     string `json:"id"`
+			Name   string `json:"name"`
+			Domain string `json:"domain"`
+		} `json:"team"`
+		Enterprise interface{} `json:"enterprise"`
+		Scopes     []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			IsSensitive bool   `json:"is_sensitive"`
+			TokenType   string `json:"token_type"`
+		} `json:"scopes"`
+		Message string `json:"message"`
+	} `json:"app_request"`
+}
+
+type AppUninstalledTeamEvent struct {
+	Type       string `json:"type"`
+	AppID      string `json:"app_id"`
+	AppName    string `json:"app_name"`
+	AppOwnerID string `json:"app_owner_id"`
+	UserID     string `json:"user_id"`
+	TeamID     string `json:"team_id"`
+	TeamDomain string `json:"team_domain"`
+	EventTs    string `json:"event_ts"`
+}
+
+type CallRejectedEvent struct {
+	Token    string `json:"token"`
+	TeamID   string `json:"team_id"`
+	APIAppID string `json:"api_app_id"`
+	Event    struct {
+		Type             string `json:"type"`
+		CallID           string `json:"call_id"`
+		UserID           string `json:"user_id"`
+		ChannelID        string `json:"channel_id"`
+		ExternalUniqueID string `json:"external_unique_id"`
+	} `json:"event"`
+	Type        string   `json:"type"`
+	EventID     string   `json:"event_id"`
+	AuthedUsers []string `json:"authed_users"`
+}
+
+type ChannelSharedEvent struct {
+	Type            string `json:"type"`
+	ConnectedTeamID string `json:"connected_team_id"`
+	Channel         string `json:"channel"`
+	EventTs         string `json:"event_ts"`
+}
+
+type FileCreatedEvent struct {
+	Type   string `json:"type"`
+	FileID string `json:"file_id"`
+	File   struct {
+		ID string `json:"id"`
+	} `json:"file"`
+}
+
+type FilePublicEvent struct {
+	Type   string `json:"type"`
+	FileID string `json:"file_id"`
+	File   struct {
+		ID string `json:"id"`
+	} `json:"file"`
+}
+
+type FunctionExecutedEvent struct {
+	Type     string `json:"type"`
+	Function struct {
+		ID              string `json:"id"`
+		CallbackID      string `json:"callback_id"`
+		Title           string `json:"title"`
+		Description     string `json:"description"`
+		Type            string `json:"type"`
+		InputParameters []struct {
+			Type        string `json:"type"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Title       string `json:"title"`
+			IsRequired  bool   `json:"is_required"`
+		} `json:"input_parameters"`
+		OutputParameters []struct {
+			Type        string `json:"type"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Title       string `json:"title"`
+			IsRequired  bool   `json:"is_required"`
+		} `json:"output_parameters"`
+		AppID       string `json:"app_id"`
+		DateCreated int64  `json:"date_created"`
+		DateUpdated int64  `json:"date_updated"`
+		DateDeleted int64  `json:"date_deleted"`
+	} `json:"function"`
+	Inputs              map[string]string `json:"inputs"`
+	FunctionExecutionID string            `json:"function_execution_id"`
+	WorkflowExecutionID string            `json:"workflow_execution_id"`
+	EventTs             string            `json:"event_ts"`
+	BotAccessToken      string            `json:"bot_access_token"`
+}
+
+type InviteRequestedEvent struct {
+	Type          string `json:"type"`
+	InviteRequest struct {
+		ID            string   `json:"id"`
+		Email         string   `json:"email"`
+		DateCreated   int64    `json:"date_created"`
+		RequesterIDs  []string `json:"requester_ids"`
+		ChannelIDs    []string `json:"channel_ids"`
+		InviteType    string   `json:"invite_type"`
+		RealName      string   `json:"real_name"`
+		DateExpire    int64    `json:"date_expire"`
+		RequestReason string   `json:"request_reason"`
+		Team          struct {
+			ID     string `json:"id"`
+			Name   string `json:"name"`
+			Domain string `json:"domain"`
+		} `json:"team"`
+	} `json:"invite_request"`
+}
+
+type StarAddedEvent struct {
+	Type string `json:"type"`
+	User string `json:"user"`
+	Item struct {
+	} `json:"item"`
+	EventTS string `json:"event_ts"`
+}
+
+type StarRemovedEvent struct {
+	Type string `json:"type"`
+	User string `json:"user"`
+	Item struct {
+	} `json:"item"`
+	EventTS string `json:"event_ts"`
+}
+
+type UserHuddleChangedEvent struct {
+	Type    string `json:"type"`
+	User    User   `json:"user"`
+	CacheTS int64  `json:"cache_ts"`
+	EventTS string `json:"event_ts"`
+}
+
+type User struct {
+	ID                     string  `json:"id"`
+	TeamID                 string  `json:"team_id"`
+	Name                   string  `json:"name"`
+	Deleted                bool    `json:"deleted"`
+	Color                  string  `json:"color"`
+	RealName               string  `json:"real_name"`
+	TZ                     string  `json:"tz"`
+	TZLabel                string  `json:"tz_label"`
+	TZOffset               int     `json:"tz_offset"`
+	Profile                Profile `json:"profile"`
+	IsAdmin                bool    `json:"is_admin"`
+	IsOwner                bool    `json:"is_owner"`
+	IsPrimaryOwner         bool    `json:"is_primary_owner"`
+	IsRestricted           bool    `json:"is_restricted"`
+	IsUltraRestricted      bool    `json:"is_ultra_restricted"`
+	IsBot                  bool    `json:"is_bot"`
+	IsAppUser              bool    `json:"is_app_user"`
+	Updated                int64   `json:"updated"`
+	IsEmailConfirmed       bool    `json:"is_email_confirmed"`
+	WhoCanShareContactCard string  `json:"who_can_share_contact_card"`
+	Locale                 string  `json:"locale"`
+}
+
+type Profile struct {
+	Title                  string                 `json:"title"`
+	Phone                  string                 `json:"phone"`
+	Skype                  string                 `json:"skype"`
+	RealName               string                 `json:"real_name"`
+	RealNameNormalized     string                 `json:"real_name_normalized"`
+	DisplayName            string                 `json:"display_name"`
+	DisplayNameNormalized  string                 `json:"display_name_normalized"`
+	Fields                 map[string]interface{} `json:"fields"`
+	StatusText             string                 `json:"status_text"`
+	StatusEmoji            string                 `json:"status_emoji"`
+	StatusEmojiDisplayInfo []interface{}          `json:"status_emoji_display_info"`
+	StatusExpiration       int                    `json:"status_expiration"`
+	AvatarHash             string                 `json:"avatar_hash"`
+	FirstName              string                 `json:"first_name"`
+	LastName               string                 `json:"last_name"`
+	Image24                string                 `json:"image_24"`
+	Image32                string                 `json:"image_32"`
+	Image48                string                 `json:"image_48"`
+	Image72                string                 `json:"image_72"`
+	Image192               string                 `json:"image_192"`
+	Image512               string                 `json:"image_512"`
+	StatusTextCanonical    string                 `json:"status_text_canonical"`
+	Team                   string                 `json:"team"`
+}
+
+type UserStatusChangedEvent struct {
+	Type    string `json:"type"`
+	User    User   `json:"user"`
+	CacheTS int64  `json:"cache_ts"`
+	EventTS string `json:"event_ts"`
+}
+
+type Actor struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	IsBot       bool   `json:"is_bot"`
+	TeamID      string `json:"team_id"`
+	Timezone    string `json:"timezone"`
+	RealName    string `json:"real_name"`
+	DisplayName string `json:"display_name"`
+}
+
+type TargetUser struct {
+	Email    string `json:"email"`
+	InviteID string `json:"invite_id"`
+}
+
+type TeamIcon struct {
+	Image34      string `json:"image_34"`
+	ImageDefault bool   `json:"image_default"`
+}
+
+type Team struct {
+	ID                  string   `json:"id"`
+	Icon                TeamIcon `json:"icon"`
+	Name                string   `json:"name"`
+	Domain              string   `json:"domain"`
+	IsVerified          bool     `json:"is_verified"`
+	DateCreated         int64    `json:"date_created"`
+	AvatarBaseURL       string   `json:"avatar_base_url"`
+	RequiresSponsorship bool     `json:"requires_sponsorship"`
+}
+
+type SharedChannelInviteRequestedEvent struct {
+	Actor                       Actor        `json:"actor"`
+	ChannelID                   string       `json:"channel_id"`
+	EventType                   string       `json:"event_type"`
+	ChannelName                 string       `json:"channel_name"`
+	ChannelType                 string       `json:"channel_type"`
+	TargetUsers                 []TargetUser `json:"target_users"`
+	TeamsInChannel              []Team       `json:"teams_in_channel"`
+	IsExternalLimited           bool         `json:"is_external_limited"`
+	ChannelDateCreated          int64        `json:"channel_date_created"`
+	ChannelMessageLatestCounted int64        `json:"channel_message_latest_counted_timestamp"`
+}
+
 type EventsAPIType string
 
 const (
@@ -585,9 +1157,9 @@ const (
 	LinkShared = EventsAPIType("link_shared")
 	// Message A message was posted to a channel, private channel (group), im, or mim
 	Message = EventsAPIType("message")
-	// Member Joined Channel
+	// MemberJoinedChannel is sent if a member joined a channel.
 	MemberJoinedChannel = EventsAPIType("member_joined_channel")
-	// Member Left Channel
+	// MemberLeftChannel is sent if a member left a channel.
 	MemberLeftChannel = EventsAPIType("member_left_channel")
 	// PinAdded An item was pinned to a channel
 	PinAdded = EventsAPIType("pin_added")
@@ -599,6 +1171,14 @@ const (
 	ReactionRemoved = EventsAPIType("reaction_removed")
 	// TeamJoin A new user joined the workspace
 	TeamJoin = EventsAPIType("team_join")
+	// Slack connect app or bot invite received
+	SharedChannelInviteReceived = EventsAPIType("shared_channel_invite_received")
+	// Slack connect channel invite approved
+	SharedChannelInviteApproved = EventsAPIType("shared_channel_invite_approved")
+	// Slack connect channel invite declined
+	SharedChannelInviteDeclined = EventsAPIType("shared_channel_invite_declined")
+	// Slack connect channel invite accepted by an end user
+	SharedChannelInviteAccepted = EventsAPIType("shared_channel_invite_accepted")
 	// TokensRevoked APP's API tokes are revoked
 	TokensRevoked = EventsAPIType("tokens_revoked")
 	// EmojiChanged A custom emoji has been added or changed
@@ -607,56 +1187,167 @@ const (
 	WorkflowStepExecute = EventsAPIType("workflow_step_execute")
 	// MessageMetadataPosted A message with metadata was posted
 	MessageMetadataPosted = EventsAPIType("message_metadata_posted")
-	// MessageMetadataPosted A message with metadata was updated
+	// MessageMetadataUpdated A message with metadata was updated
 	MessageMetadataUpdated = EventsAPIType("message_metadata_updated")
-	// MessageMetadataPosted A message with metadata was deleted
+	// MessageMetadataDeleted A message with metadata was deleted
 	MessageMetadataDeleted = EventsAPIType("message_metadata_deleted")
 	// TeamAccessGranted is sent if access to teams was granted for your org-wide app.
 	TeamAccessGranted = EventsAPIType("team_access_granted")
-	// TeamAccessrevoked is sent if access to teams was revoked for your org-wide app.
-	TeamAccessrevoked = EventsAPIType("team_access_revoked")
+	// TeamAccessRevoked is sent if access to teams was revoked for your org-wide app.
+	TeamAccessRevoked = EventsAPIType("team_access_revoked")
+	// UserProfileChanged is sent if a user's profile information has changed.
+	UserProfileChanged = EventsAPIType("user_profile_changed")
+	// ChannelHistoryChanged The history of a channel changed
+	ChannelHistoryChanged = EventsAPIType("channel_history_changed")
+	// CommandsChanged A command was changed
+	CommandsChanged = EventsAPIType("commands_changed")
+	// DndUpdated Do Not Disturb settings were updated
+	DndUpdated = EventsAPIType("dnd_updated")
+	// DndUpdatedUser Do Not Disturb settings for a user were updated
+	DndUpdatedUser = EventsAPIType("dnd_updated_user")
+	// EmailDomainChanged The email domain changed
+	EmailDomainChanged = EventsAPIType("email_domain_changed")
+	// GroupClose A group was closed
+	GroupClose = EventsAPIType("group_close")
+	// GroupHistoryChanged The history of a group changed
+	GroupHistoryChanged = EventsAPIType("group_history_changed")
+	// GroupOpen A group was opened
+	GroupOpen = EventsAPIType("group_open")
+	// ImClose An instant message channel was closed
+	ImClose = EventsAPIType("im_close")
+	// ImCreated An instant message channel was created
+	ImCreated = EventsAPIType("im_created")
+	// ImHistoryChanged The history of an instant message channel changed
+	ImHistoryChanged = EventsAPIType("im_history_changed")
+	// ImOpen An instant message channel was opened
+	ImOpen = EventsAPIType("im_open")
+	// SubteamCreated A subteam was created
+	SubteamCreated = EventsAPIType("subteam_created")
+	// SubteamMembersChanged The members of a subteam changed
+	SubteamMembersChanged = EventsAPIType("subteam_members_changed")
+	// SubteamSelfAdded The current user was added to a subteam
+	SubteamSelfAdded = EventsAPIType("subteam_self_added")
+	// SubteamSelfRemoved The current user was removed from a subteam
+	SubteamSelfRemoved = EventsAPIType("subteam_self_removed")
+	// SubteamUpdated A subteam was updated
+	SubteamUpdated = EventsAPIType("subteam_updated")
+	// TeamDomainChange The team's domain changed
+	TeamDomainChange = EventsAPIType("team_domain_change")
+	// TeamRename The team was renamed
+	TeamRename = EventsAPIType("team_rename")
+	// UserChange A user object has changed
+	UserChange = EventsAPIType("user_change")
+	// AppDeleted is an event when an app is deleted from a workspace
+	AppDeleted = EventsAPIType("app_deleted")
+	// AppInstalled is an event when an app is installed to a workspace
+	AppInstalled = EventsAPIType("app_installed")
+	// AppRequested is an event when a user requests to install an app to a workspace
+	AppRequested = EventsAPIType("app_requested")
+	// AppUninstalledTeam is an event when an app is uninstalled from a team
+	AppUninstalledTeam = EventsAPIType("app_uninstalled_team")
+	// CallRejected is an event when a Slack call is rejected
+	CallRejected = EventsAPIType("call_rejected")
+	// ChannelShared is an event when a channel is shared with another workspace
+	ChannelShared = EventsAPIType("channel_shared")
+	// FileCreated is an event when a file is created in a workspace
+	FileCreated = EventsAPIType("file_created")
+	// FilePublic is an event when a file is made public in a workspace
+	FilePublic = EventsAPIType("file_public")
+	// FunctionExecuted is an event when a Slack function is executed
+	FunctionExecuted = EventsAPIType("function_executed")
+	// InviteRequested is an event when a user requests an invite to a workspace
+	InviteRequested = EventsAPIType("invite_requested")
+	// SharedChannelInviteRequested is an event when an invitation to share a channel is requested
+	SharedChannelInviteRequested = EventsAPIType("shared_channel_invite_requested")
+	// StarAdded is an event when a star is added to a message or file
+	StarAdded = EventsAPIType("star_added")
+	// StarRemoved is an event when a star is removed from a message or file
+	StarRemoved = EventsAPIType("star_removed")
+	// UserHuddleChanged is an event when a user's huddle status changes
+	UserHuddleChanged = EventsAPIType("user_huddle_changed")
+	// UserStatusChanged is an event when a user's status changes
+	UserStatusChanged = EventsAPIType("user_status_changed")
 )
 
 // EventsAPIInnerEventMapping maps INNER Event API events to their corresponding struct
 // implementations. The structs should be instances of the unmarshalling
 // target for the matching event type.
 var EventsAPIInnerEventMapping = map[EventsAPIType]interface{}{
-	AppMention:             AppMentionEvent{},
-	AppHomeOpened:          AppHomeOpenedEvent{},
-	AppUninstalled:         AppUninstalledEvent{},
-	ChannelCreated:         ChannelCreatedEvent{},
-	ChannelDeleted:         ChannelDeletedEvent{},
-	ChannelArchive:         ChannelArchiveEvent{},
-	ChannelUnarchive:       ChannelUnarchiveEvent{},
-	ChannelLeft:            ChannelLeftEvent{},
-	ChannelRename:          ChannelRenameEvent{},
-	ChannelIDChanged:       ChannelIDChangedEvent{},
-	FileChange:             FileChangeEvent{},
-	FileDeleted:            FileDeletedEvent{},
-	FileShared:             FileSharedEvent{},
-	FileUnshared:           FileUnsharedEvent{},
-	GroupDeleted:           GroupDeletedEvent{},
-	GroupArchive:           GroupArchiveEvent{},
-	GroupUnarchive:         GroupUnarchiveEvent{},
-	GroupLeft:              GroupLeftEvent{},
-	GroupRename:            GroupRenameEvent{},
-	GridMigrationFinished:  GridMigrationFinishedEvent{},
-	GridMigrationStarted:   GridMigrationStartedEvent{},
-	LinkShared:             LinkSharedEvent{},
-	Message:                MessageEvent{},
-	MemberJoinedChannel:    MemberJoinedChannelEvent{},
-	MemberLeftChannel:      MemberLeftChannelEvent{},
-	PinAdded:               PinAddedEvent{},
-	PinRemoved:             PinRemovedEvent{},
-	ReactionAdded:          ReactionAddedEvent{},
-	ReactionRemoved:        ReactionRemovedEvent{},
-	TeamJoin:               TeamJoinEvent{},
-	TokensRevoked:          TokensRevokedEvent{},
-	EmojiChanged:           EmojiChangedEvent{},
-	WorkflowStepExecute:    WorkflowStepExecuteEvent{},
-	MessageMetadataPosted:  MessageMetadataPostedEvent{},
-	MessageMetadataUpdated: MessageMetadataUpdatedEvent{},
-	MessageMetadataDeleted: MessageMetadataDeletedEvent{},
-	TeamAccessGranted:      TeamAccessGrantedEvent{},
-	TeamAccessrevoked:      TeamAccessRevokedEvent{},
+	AppMention:                   AppMentionEvent{},
+	AppHomeOpened:                AppHomeOpenedEvent{},
+	AppUninstalled:               AppUninstalledEvent{},
+	ChannelCreated:               ChannelCreatedEvent{},
+	ChannelDeleted:               ChannelDeletedEvent{},
+	ChannelArchive:               ChannelArchiveEvent{},
+	ChannelUnarchive:             ChannelUnarchiveEvent{},
+	ChannelLeft:                  ChannelLeftEvent{},
+	ChannelRename:                ChannelRenameEvent{},
+	ChannelIDChanged:             ChannelIDChangedEvent{},
+	FileChange:                   FileChangeEvent{},
+	FileDeleted:                  FileDeletedEvent{},
+	FileShared:                   FileSharedEvent{},
+	FileUnshared:                 FileUnsharedEvent{},
+	GroupDeleted:                 GroupDeletedEvent{},
+	GroupArchive:                 GroupArchiveEvent{},
+	GroupUnarchive:               GroupUnarchiveEvent{},
+	GroupLeft:                    GroupLeftEvent{},
+	GroupRename:                  GroupRenameEvent{},
+	GridMigrationFinished:        GridMigrationFinishedEvent{},
+	GridMigrationStarted:         GridMigrationStartedEvent{},
+	LinkShared:                   LinkSharedEvent{},
+	Message:                      MessageEvent{},
+	MemberJoinedChannel:          MemberJoinedChannelEvent{},
+	MemberLeftChannel:            MemberLeftChannelEvent{},
+	PinAdded:                     PinAddedEvent{},
+	PinRemoved:                   PinRemovedEvent{},
+	ReactionAdded:                ReactionAddedEvent{},
+	ReactionRemoved:              ReactionRemovedEvent{},
+	SharedChannelInviteApproved:  SharedChannelInviteApprovedEvent{},
+	SharedChannelInviteAccepted:  SharedChannelInviteAcceptedEvent{},
+	SharedChannelInviteDeclined:  SharedChannelInviteDeclinedEvent{},
+	SharedChannelInviteReceived:  SharedChannelInviteReceivedEvent{},
+	TeamJoin:                     TeamJoinEvent{},
+	TokensRevoked:                TokensRevokedEvent{},
+	EmojiChanged:                 EmojiChangedEvent{},
+	WorkflowStepExecute:          WorkflowStepExecuteEvent{},
+	MessageMetadataPosted:        MessageMetadataPostedEvent{},
+	MessageMetadataUpdated:       MessageMetadataUpdatedEvent{},
+	MessageMetadataDeleted:       MessageMetadataDeletedEvent{},
+	TeamAccessGranted:            TeamAccessGrantedEvent{},
+	TeamAccessRevoked:            TeamAccessRevokedEvent{},
+	UserProfileChanged:           UserProfileChangedEvent{},
+	ChannelHistoryChanged:        ChannelHistoryChangedEvent{},
+	DndUpdated:                   DndUpdatedEvent{},
+	DndUpdatedUser:               DndUpdatedUserEvent{},
+	EmailDomainChanged:           EmailDomainChangedEvent{},
+	GroupClose:                   GroupCloseEvent{},
+	GroupHistoryChanged:          GroupHistoryChangedEvent{},
+	GroupOpen:                    GroupOpenEvent{},
+	ImClose:                      ImCloseEvent{},
+	ImCreated:                    ImCreatedEvent{},
+	ImHistoryChanged:             ImHistoryChangedEvent{},
+	ImOpen:                       ImOpenEvent{},
+	SubteamCreated:               SubteamCreatedEvent{},
+	SubteamMembersChanged:        SubteamMembersChangedEvent{},
+	SubteamSelfAdded:             SubteamSelfAddedEvent{},
+	SubteamSelfRemoved:           SubteamSelfRemovedEvent{},
+	SubteamUpdated:               SubteamUpdatedEvent{},
+	TeamDomainChange:             TeamDomainChangeEvent{},
+	TeamRename:                   TeamRenameEvent{},
+	UserChange:                   UserChangeEvent{},
+	AppDeleted:                   AppDeletedEvent{},
+	AppInstalled:                 AppInstalledEvent{},
+	AppRequested:                 AppRequestedEvent{},
+	AppUninstalledTeam:           AppUninstalledTeamEvent{},
+	CallRejected:                 CallRejectedEvent{},
+	ChannelShared:                ChannelSharedEvent{},
+	FileCreated:                  FileCreatedEvent{},
+	FilePublic:                   FilePublicEvent{},
+	FunctionExecuted:             FunctionExecutedEvent{},
+	InviteRequested:              InviteRequestedEvent{},
+	SharedChannelInviteRequested: SharedChannelInviteRequestedEvent{},
+	StarAdded:                    StarAddedEvent{},
+	StarRemoved:                  StarRemovedEvent{},
+	UserHuddleChanged:            UserHuddleChangedEvent{},
+	UserStatusChanged:            UserStatusChangedEvent{},
 }

--- a/vendor/github.com/slack-go/slack/slackevents/parsers.go
+++ b/vendor/github.com/slack-go/slack/slackevents/parsers.go
@@ -117,7 +117,7 @@ func parseInnerEvent(e *EventsAPICallbackEvent) (EventsAPIEvent, error) {
 			e.EnterpriseID,
 			nil,
 			EventsAPIInnerEvent{},
-		}, fmt.Errorf("Inner Event does not exist! %s", iE.Type)
+		}, fmt.Errorf("inner Event does not exist! %s", iE.Type)
 	}
 	t := reflect.TypeOf(v)
 	recvEvent := reflect.New(t).Interface()
@@ -192,7 +192,7 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 	}
 
 	if !cfg.TokenVerified {
-		return EventsAPIEvent{}, errors.New("Invalid verification token")
+		return EventsAPIEvent{}, errors.New("invalid verification token")
 	}
 
 	if e.Type == CallbackEvent {
@@ -212,6 +212,32 @@ func ParseEvent(rawEvent json.RawMessage, opts ...Option) (EventsAPIEvent, error
 		}
 		return innerEvent, nil
 	}
+
+	if e.Type == AppRateLimited {
+		appRateLimitedEvent := &EventsAPIAppRateLimited{}
+		err = json.Unmarshal(rawEvent, appRateLimitedEvent)
+		if err != nil {
+			return EventsAPIEvent{
+				"",
+				"",
+				"unmarshalling_error",
+				"",
+				"",
+				&slack.UnmarshallingErrorEvent{ErrorObj: err},
+				EventsAPIInnerEvent{},
+			}, err
+		}
+		return EventsAPIEvent{
+			e.Token,
+			e.TeamID,
+			e.Type,
+			e.APIAppID,
+			e.EnterpriseID,
+			appRateLimitedEvent,
+			EventsAPIInnerEvent{},
+		}, nil
+	}
+
 	urlVerificationEvent := &EventsAPIURLVerificationEvent{}
 	err = json.Unmarshal(rawEvent, urlVerificationEvent)
 	if err != nil {

--- a/vendor/github.com/slack-go/slack/slash.go
+++ b/vendor/github.com/slack-go/slack/slash.go
@@ -1,25 +1,29 @@
 package slack
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
 )
 
 // SlashCommand contains information about a request of the slash command
 type SlashCommand struct {
-	Token          string `json:"token"`
-	TeamID         string `json:"team_id"`
-	TeamDomain     string `json:"team_domain"`
-	EnterpriseID   string `json:"enterprise_id,omitempty"`
-	EnterpriseName string `json:"enterprise_name,omitempty"`
-	ChannelID      string `json:"channel_id"`
-	ChannelName    string `json:"channel_name"`
-	UserID         string `json:"user_id"`
-	UserName       string `json:"user_name"`
-	Command        string `json:"command"`
-	Text           string `json:"text"`
-	ResponseURL    string `json:"response_url"`
-	TriggerID      string `json:"trigger_id"`
-	APIAppID       string `json:"api_app_id"`
+	Token               string `json:"token"`
+	TeamID              string `json:"team_id"`
+	TeamDomain          string `json:"team_domain"`
+	EnterpriseID        string `json:"enterprise_id,omitempty"`
+	EnterpriseName      string `json:"enterprise_name,omitempty"`
+	IsEnterpriseInstall bool   `json:"is_enterprise_install"`
+	ChannelID           string `json:"channel_id"`
+	ChannelName         string `json:"channel_name"`
+	UserID              string `json:"user_id"`
+	UserName            string `json:"user_name"`
+	Command             string `json:"command"`
+	Text                string `json:"text"`
+	ResponseURL         string `json:"response_url"`
+	TriggerID           string `json:"trigger_id"`
+	APIAppID            string `json:"api_app_id"`
 }
 
 // SlashCommandParse will parse the request of the slash command
@@ -32,6 +36,7 @@ func SlashCommandParse(r *http.Request) (s SlashCommand, err error) {
 	s.TeamDomain = r.PostForm.Get("team_domain")
 	s.EnterpriseID = r.PostForm.Get("enterprise_id")
 	s.EnterpriseName = r.PostForm.Get("enterprise_name")
+	s.IsEnterpriseInstall = r.PostForm.Get("is_enterprise_install") == "true"
 	s.ChannelID = r.PostForm.Get("channel_id")
 	s.ChannelName = r.PostForm.Get("channel_name")
 	s.UserID = r.PostForm.Get("user_id")
@@ -52,4 +57,35 @@ func (s SlashCommand) ValidateToken(verificationTokens ...string) bool {
 		}
 	}
 	return false
+}
+
+// UnmarshalJSON handles is_enterprise_install being either a boolean or a
+// string when parsing JSON from various payloads
+func (s *SlashCommand) UnmarshalJSON(data []byte) error {
+	type SlashCommandCopy SlashCommand
+	scopy := &struct {
+		*SlashCommandCopy
+		IsEnterpriseInstall interface{} `json:"is_enterprise_install"`
+	}{
+		SlashCommandCopy: (*SlashCommandCopy)(s),
+	}
+
+	if err := json.Unmarshal(data, scopy); err != nil {
+		return err
+	}
+
+	switch rawValue := scopy.IsEnterpriseInstall.(type) {
+	case string:
+		b, err := strconv.ParseBool(rawValue)
+		if err != nil {
+			return fmt.Errorf("parsing boolean for is_enterprise_install: %w", err)
+		}
+		s.IsEnterpriseInstall = b
+	case bool:
+		s.IsEnterpriseInstall = rawValue
+	default:
+		return fmt.Errorf("wrong data type for is_enterprise_install: %T", scopy.IsEnterpriseInstall)
+	}
+
+	return nil
 }

--- a/vendor/github.com/slack-go/slack/stars.go
+++ b/vendor/github.com/slack-go/slack/stars.go
@@ -36,12 +36,14 @@ func NewStarsParameters() StarsParameters {
 	}
 }
 
-// AddStar stars an item in a channel
+// AddStar stars an item in a channel.
+// For more information see the AddStarContext documentation.
 func (api *Client) AddStar(channel string, item ItemRef) error {
 	return api.AddStarContext(context.Background(), channel, item)
 }
 
-// AddStarContext stars an item in a channel with a custom context
+// AddStarContext stars an item in a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/stars.add
 func (api *Client) AddStarContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
@@ -65,12 +67,14 @@ func (api *Client) AddStarContext(ctx context.Context, channel string, item Item
 	return response.Err()
 }
 
-// RemoveStar removes a starred item from a channel
+// RemoveStar removes a starred item from a channel.
+// For more information see the RemoveStarContext documentation.
 func (api *Client) RemoveStar(channel string, item ItemRef) error {
 	return api.RemoveStarContext(context.Background(), channel, item)
 }
 
-// RemoveStarContext removes a starred item from a channel with a custom context
+// RemoveStarContext removes a starred item from a channel with a custom context.
+// Slack API docs: https://api.slack.com/methods/stars.remove
 func (api *Client) RemoveStarContext(ctx context.Context, channel string, item ItemRef) error {
 	values := url.Values{
 		"channel": {channel},
@@ -94,12 +98,14 @@ func (api *Client) RemoveStarContext(ctx context.Context, channel string, item I
 	return response.Err()
 }
 
-// ListStars returns information about the stars a user added
+// ListStars returns information about the stars a user added.
+// For more information see the ListStarsContext documentation.
 func (api *Client) ListStars(params StarsParameters) ([]Item, *Paging, error) {
 	return api.ListStarsContext(context.Background(), params)
 }
 
-// ListStarsContext returns information about the stars a user added with a custom context
+// ListStarsContext returns information about the stars a user added with a custom context.
+// Slack API docs: https://api.slack.com/methods/stars.list
 func (api *Client) ListStarsContext(ctx context.Context, params StarsParameters) ([]Item, *Paging, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -147,7 +153,6 @@ func (api *Client) GetStarred(params StarsParameters) ([]StarredItem, *Paging, e
 }
 
 // GetStarredContext returns a list of StarredItem items with a custom context
-//
 // For more details see GetStarred
 func (api *Client) GetStarredContext(ctx context.Context, params StarsParameters) ([]StarredItem, *Paging, error) {
 	items, paging, err := api.ListStarsContext(ctx, params)

--- a/vendor/github.com/slack-go/slack/team.go
+++ b/vendor/github.com/slack-go/slack/team.go
@@ -74,8 +74,9 @@ type BillingActive struct {
 
 // AccessLogParameters contains all the parameters necessary (including the optional ones) for a GetAccessLogs() request
 type AccessLogParameters struct {
-	Count int
-	Page  int
+	TeamID string
+	Count  int
+	Page   int
 }
 
 // NewAccessLogParameters provides an instance of AccessLogParameters with all the sane default values set
@@ -124,12 +125,14 @@ func (api *Client) teamProfileRequest(ctx context.Context, client httpClient, pa
 	return response, response.Err()
 }
 
-// GetTeamInfo gets the Team Information of the user
+// GetTeamInfo gets the Team Information of the user.
+// For more information see the GetTeamInfoContext documentation.
 func (api *Client) GetTeamInfo() (*TeamInfo, error) {
 	return api.GetTeamInfoContext(context.Background())
 }
 
-// GetOtherTeamInfoContext gets Team information for any team with a custom context
+// GetOtherTeamInfoContext gets Team information for any team with a custom context.
+// Slack API docs: https://api.slack.com/methods/team.info
 func (api *Client) GetOtherTeamInfoContext(ctx context.Context, team string) (*TeamInfo, error) {
 	if team == "" {
 		return api.GetTeamInfoContext(ctx)
@@ -145,12 +148,14 @@ func (api *Client) GetOtherTeamInfoContext(ctx context.Context, team string) (*T
 	return &response.Team, nil
 }
 
-// GetOtherTeamInfo gets Team information for any team
+// GetOtherTeamInfo gets Team information for any team.
+// For more information see the GetOtherTeamInfoContext documentation.
 func (api *Client) GetOtherTeamInfo(team string) (*TeamInfo, error) {
 	return api.GetOtherTeamInfoContext(context.Background(), team)
 }
 
-// GetTeamInfoContext gets the Team Information of the user with a custom context
+// GetTeamInfoContext gets the Team Information of the user with a custom context.
+// Slack API docs: https://api.slack.com/methods/team.info
 func (api *Client) GetTeamInfoContext(ctx context.Context) (*TeamInfo, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -163,15 +168,20 @@ func (api *Client) GetTeamInfoContext(ctx context.Context) (*TeamInfo, error) {
 	return &response.Team, nil
 }
 
-// GetTeamProfile gets the Team Profile settings of the user
-func (api *Client) GetTeamProfile() (*TeamProfile, error) {
-	return api.GetTeamProfileContext(context.Background())
+// GetTeamProfile gets the Team Profile settings of the user.
+// For more information see the GetTeamProfileContext documentation.
+func (api *Client) GetTeamProfile(teamID ...string) (*TeamProfile, error) {
+	return api.GetTeamProfileContext(context.Background(), teamID...)
 }
 
-// GetTeamProfileContext gets the Team Profile settings of the user with a custom context
-func (api *Client) GetTeamProfileContext(ctx context.Context) (*TeamProfile, error) {
+// GetTeamProfileContext gets the Team Profile settings of the user with a custom context.
+// Slack API docs: https://api.slack.com/methods/team.profile.get
+func (api *Client) GetTeamProfileContext(ctx context.Context, teamID ...string) (*TeamProfile, error) {
 	values := url.Values{
 		"token": {api.token},
+	}
+	if len(teamID) > 0 {
+		values["team_id"] = teamID
 	}
 
 	response, err := api.teamProfileRequest(ctx, api.httpclient, "team.profile.get", values)
@@ -179,18 +189,22 @@ func (api *Client) GetTeamProfileContext(ctx context.Context) (*TeamProfile, err
 		return nil, err
 	}
 	return &response.Profile, nil
-
 }
 
-// GetAccessLogs retrieves a page of logins according to the parameters given
+// GetAccessLogs retrieves a page of logins according to the parameters given.
+// For more information see the GetAccessLogsContext documentation.
 func (api *Client) GetAccessLogs(params AccessLogParameters) ([]Login, *Paging, error) {
 	return api.GetAccessLogsContext(context.Background(), params)
 }
 
-// GetAccessLogsContext retrieves a page of logins according to the parameters given with a custom context
+// GetAccessLogsContext retrieves a page of logins according to the parameters given with a custom context.
+// Slack API docs: https://api.slack.com/methods/team.accessLogs
 func (api *Client) GetAccessLogsContext(ctx context.Context, params AccessLogParameters) ([]Login, *Paging, error) {
 	values := url.Values{
 		"token": {api.token},
+	}
+	if params.TeamID != "" {
+		values.Add("team_id", params.TeamID)
 	}
 	if params.Count != DEFAULT_LOGINS_COUNT {
 		values.Add("count", strconv.Itoa(params.Count))
@@ -206,30 +220,30 @@ func (api *Client) GetAccessLogsContext(ctx context.Context, params AccessLogPar
 	return response.Logins, &response.Paging, nil
 }
 
-// GetBillableInfo ...
-func (api *Client) GetBillableInfo(user string) (map[string]BillingActive, error) {
-	return api.GetBillableInfoContext(context.Background(), user)
+type GetBillableInfoParams struct {
+	User   string
+	TeamID string
 }
 
-// GetBillableInfoContext ...
-func (api *Client) GetBillableInfoContext(ctx context.Context, user string) (map[string]BillingActive, error) {
+// GetBillableInfo gets the billable users information of the team.
+// For more information see the GetBillableInfoContext documentation.
+func (api *Client) GetBillableInfo(params GetBillableInfoParams) (map[string]BillingActive, error) {
+	return api.GetBillableInfoContext(context.Background(), params)
+}
+
+// GetBillableInfoContext gets the billable users information of the team with a custom context.
+// Slack API docs: https://api.slack.com/methods/team.billableInfo
+func (api *Client) GetBillableInfoContext(ctx context.Context, params GetBillableInfoParams) (map[string]BillingActive, error) {
 	values := url.Values{
 		"token": {api.token},
-		"user":  {user},
 	}
 
-	return api.billableInfoRequest(ctx, "team.billableInfo", values)
-}
+	if params.TeamID != "" {
+		values.Add("team_id", params.TeamID)
+	}
 
-// GetBillableInfoForTeam returns the billing_active status of all users on the team.
-func (api *Client) GetBillableInfoForTeam() (map[string]BillingActive, error) {
-	return api.GetBillableInfoForTeamContext(context.Background())
-}
-
-// GetBillableInfoForTeamContext returns the billing_active status of all users on the team with a custom context
-func (api *Client) GetBillableInfoForTeamContext(ctx context.Context) (map[string]BillingActive, error) {
-	values := url.Values{
-		"token": {api.token},
+	if params.User != "" {
+		values.Add("user", params.User)
 	}
 
 	return api.billableInfoRequest(ctx, "team.billableInfo", values)

--- a/vendor/github.com/slack-go/slack/tokens.go
+++ b/vendor/github.com/slack-go/slack/tokens.go
@@ -1,0 +1,52 @@
+package slack
+
+import (
+	"context"
+	"net/url"
+)
+
+// RotateTokens exchanges a refresh token for a new app configuration token.
+// For more information see the RotateTokensContext documentation.
+func (api *Client) RotateTokens(configToken string, refreshToken string) (*TokenResponse, error) {
+	return api.RotateTokensContext(context.Background(), configToken, refreshToken)
+}
+
+// RotateTokensContext exchanges a refresh token for a new app configuration token with a custom context.
+// Slack API docs: https://api.slack.com/methods/tooling.tokens.rotate
+func (api *Client) RotateTokensContext(ctx context.Context, configToken string, refreshToken string) (*TokenResponse, error) {
+	if configToken == "" {
+		configToken = api.configToken
+	}
+
+	if refreshToken == "" {
+		refreshToken = api.configRefreshToken
+	}
+
+	values := url.Values{
+		"refresh_token": {refreshToken},
+	}
+
+	response := &TokenResponse{}
+	err := api.getMethod(ctx, "tooling.tokens.rotate", configToken, values, response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, response.Err()
+}
+
+// UpdateConfigTokens replaces the configuration tokens in the client with those returned by the API
+func (api *Client) UpdateConfigTokens(response *TokenResponse) {
+	api.configToken = response.Token
+	api.configRefreshToken = response.RefreshToken
+}
+
+type TokenResponse struct {
+	Token        string `json:"token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	TeamId       string `json:"team_id,omitempty"`
+	UserId       string `json:"user_id,omitempty"`
+	IssuedAt     uint64 `json:"iat,omitempty"`
+	ExpiresAt    uint64 `json:"exp,omitempty"`
+	SlackResponse
+}

--- a/vendor/github.com/slack-go/slack/usergroups.go
+++ b/vendor/github.com/slack-go/slack/usergroups.go
@@ -50,16 +50,22 @@ func (api *Client) userGroupRequest(ctx context.Context, path string, values url
 	return response, response.Err()
 }
 
-// CreateUserGroup creates a new user group
+// CreateUserGroup creates a new user group.
+// For more information see the CreateUserGroupContext documentation.
 func (api *Client) CreateUserGroup(userGroup UserGroup) (UserGroup, error) {
 	return api.CreateUserGroupContext(context.Background(), userGroup)
 }
 
-// CreateUserGroupContext creates a new user group with a custom context
+// CreateUserGroupContext creates a new user group with a custom context.
+// Slack API docs: https://api.slack.com/methods/usergroups.create
 func (api *Client) CreateUserGroupContext(ctx context.Context, userGroup UserGroup) (UserGroup, error) {
 	values := url.Values{
 		"token": {api.token},
 		"name":  {userGroup.Name},
+	}
+
+	if userGroup.TeamID != "" {
+		values["team_id"] = []string{userGroup.TeamID}
 	}
 
 	if userGroup.Handle != "" {
@@ -81,12 +87,14 @@ func (api *Client) CreateUserGroupContext(ctx context.Context, userGroup UserGro
 	return response.UserGroup, nil
 }
 
-// DisableUserGroup disables an existing user group
+// DisableUserGroup disables an existing user group.
+// For more information see the DisableUserGroupContext documentation.
 func (api *Client) DisableUserGroup(userGroup string) (UserGroup, error) {
 	return api.DisableUserGroupContext(context.Background(), userGroup)
 }
 
-// DisableUserGroupContext disables an existing user group with a custom context
+// DisableUserGroupContext disables an existing user group with a custom context.
+// Slack API docs: https://api.slack.com/methods/usergroups.disable
 func (api *Client) DisableUserGroupContext(ctx context.Context, userGroup string) (UserGroup, error) {
 	values := url.Values{
 		"token":     {api.token},
@@ -100,12 +108,14 @@ func (api *Client) DisableUserGroupContext(ctx context.Context, userGroup string
 	return response.UserGroup, nil
 }
 
-// EnableUserGroup enables an existing user group
+// EnableUserGroup enables an existing user group.
+// For more information see the EnableUserGroupContext documentation.
 func (api *Client) EnableUserGroup(userGroup string) (UserGroup, error) {
 	return api.EnableUserGroupContext(context.Background(), userGroup)
 }
 
-// EnableUserGroupContext enables an existing user group with a custom context
+// EnableUserGroupContext enables an existing user group with a custom context.
+// Slack API docs: https://api.slack.com/methods/usergroups.enable
 func (api *Client) EnableUserGroupContext(ctx context.Context, userGroup string) (UserGroup, error) {
 	values := url.Values{
 		"token":     {api.token},
@@ -121,6 +131,12 @@ func (api *Client) EnableUserGroupContext(ctx context.Context, userGroup string)
 
 // GetUserGroupsOption options for the GetUserGroups method call.
 type GetUserGroupsOption func(*GetUserGroupsParams)
+
+func GetUserGroupsOptionWithTeamID(teamID string) GetUserGroupsOption {
+	return func(params *GetUserGroupsParams) {
+		params.TeamID = teamID
+	}
+}
 
 // GetUserGroupsOptionIncludeCount include the number of users in each User Group (default: false)
 func GetUserGroupsOptionIncludeCount(b bool) GetUserGroupsOption {
@@ -145,17 +161,20 @@ func GetUserGroupsOptionIncludeUsers(b bool) GetUserGroupsOption {
 
 // GetUserGroupsParams contains arguments for GetUserGroups method call
 type GetUserGroupsParams struct {
+	TeamID          string
 	IncludeCount    bool
 	IncludeDisabled bool
 	IncludeUsers    bool
 }
 
-// GetUserGroups returns a list of user groups for the team
+// GetUserGroups returns a list of user groups for the team.
+// For more information see the GetUserGroupsContext documentation.
 func (api *Client) GetUserGroups(options ...GetUserGroupsOption) ([]UserGroup, error) {
 	return api.GetUserGroupsContext(context.Background(), options...)
 }
 
-// GetUserGroupsContext returns a list of user groups for the team with a custom context
+// GetUserGroupsContext returns a list of user groups for the team with a custom context.
+// Slack API docs: https://api.slack.com/methods/usergroups.list
 func (api *Client) GetUserGroupsContext(ctx context.Context, options ...GetUserGroupsOption) ([]UserGroup, error) {
 	params := GetUserGroupsParams{}
 
@@ -165,6 +184,9 @@ func (api *Client) GetUserGroupsContext(ctx context.Context, options ...GetUserG
 
 	values := url.Values{
 		"token": {api.token},
+	}
+	if params.TeamID != "" {
+		values.Add("team_id", params.TeamID)
 	}
 	if params.IncludeCount {
 		values.Add("include_count", "true")
@@ -222,12 +244,14 @@ type UpdateUserGroupsParams struct {
 	Channels    *[]string
 }
 
-// UpdateUserGroup will update an existing user group
+// UpdateUserGroup will update an existing user group.
+// For more information see the UpdateUserGroupContext documentation.
 func (api *Client) UpdateUserGroup(userGroupID string, options ...UpdateUserGroupsOption) (UserGroup, error) {
 	return api.UpdateUserGroupContext(context.Background(), userGroupID, options...)
 }
 
-// UpdateUserGroupContext will update an existing user group with a custom context
+// UpdateUserGroupContext will update an existing user group with a custom context.
+// Slack API docs: https://api.slack.com/methods/usergroups.update
 func (api *Client) UpdateUserGroupContext(ctx context.Context, userGroupID string, options ...UpdateUserGroupsOption) (UserGroup, error) {
 	params := UpdateUserGroupsParams{}
 
@@ -263,12 +287,14 @@ func (api *Client) UpdateUserGroupContext(ctx context.Context, userGroupID strin
 	return response.UserGroup, nil
 }
 
-// GetUserGroupMembers will retrieve the current list of users in a group
+// GetUserGroupMembers will retrieve the current list of users in a group.
+// For more information see the GetUserGroupMembersContext documentation.
 func (api *Client) GetUserGroupMembers(userGroup string) ([]string, error) {
 	return api.GetUserGroupMembersContext(context.Background(), userGroup)
 }
 
-// GetUserGroupMembersContext will retrieve the current list of users in a group with a custom context
+// GetUserGroupMembersContext will retrieve the current list of users in a group with a custom context.
+// Slack API docs: https://api.slack.com/methods/usergroups.users.list
 func (api *Client) GetUserGroupMembersContext(ctx context.Context, userGroup string) ([]string, error) {
 	values := url.Values{
 		"token":     {api.token},
@@ -282,12 +308,14 @@ func (api *Client) GetUserGroupMembersContext(ctx context.Context, userGroup str
 	return response.Users, nil
 }
 
-// UpdateUserGroupMembers will update the members of an existing user group
+// UpdateUserGroupMembers will update the members of an existing user group.
+// For more information see the UpdateUserGroupMembersContext documentation.
 func (api *Client) UpdateUserGroupMembers(userGroup string, members string) (UserGroup, error) {
 	return api.UpdateUserGroupMembersContext(context.Background(), userGroup, members)
 }
 
-// UpdateUserGroupMembersContext will update the members of an existing user group with a custom context
+// UpdateUserGroupMembersContext will update the members of an existing user group with a custom context.
+// Slack API docs: https://api.slack.com/methods/usergroups.update
 func (api *Client) UpdateUserGroupMembersContext(ctx context.Context, userGroup string, members string) (UserGroup, error) {
 	values := url.Values{
 		"token":     {api.token},

--- a/vendor/github.com/slack-go/slack/users.go
+++ b/vendor/github.com/slack-go/slack/users.go
@@ -17,31 +17,32 @@ const (
 
 // UserProfile contains all the information details of a given user
 type UserProfile struct {
-	FirstName              string                              `json:"first_name"`
-	LastName               string                              `json:"last_name"`
+	FirstName              string                              `json:"first_name,omitempty"`
+	LastName               string                              `json:"last_name,omitempty"`
 	RealName               string                              `json:"real_name"`
 	RealNameNormalized     string                              `json:"real_name_normalized"`
 	DisplayName            string                              `json:"display_name"`
 	DisplayNameNormalized  string                              `json:"display_name_normalized"`
-	Email                  string                              `json:"email"`
-	Skype                  string                              `json:"skype"`
-	Phone                  string                              `json:"phone"`
+	AvatarHash             string                              `json:"avatar_hash"`
+	Email                  string                              `json:"email,omitempty"`
+	Skype                  string                              `json:"skyp,omitempty"`
+	Phone                  string                              `json:"phone,omitempty"`
 	Image24                string                              `json:"image_24"`
 	Image32                string                              `json:"image_32"`
 	Image48                string                              `json:"image_48"`
 	Image72                string                              `json:"image_72"`
 	Image192               string                              `json:"image_192"`
 	Image512               string                              `json:"image_512"`
-	ImageOriginal          string                              `json:"image_original"`
-	Title                  string                              `json:"title"`
+	ImageOriginal          string                              `json:"image_original,omitempty"`
+	Title                  string                              `json:"title,omitempty"`
 	BotID                  string                              `json:"bot_id,omitempty"`
 	ApiAppID               string                              `json:"api_app_id,omitempty"`
 	StatusText             string                              `json:"status_text,omitempty"`
 	StatusEmoji            string                              `json:"status_emoji,omitempty"`
 	StatusEmojiDisplayInfo []UserProfileStatusEmojiDisplayInfo `json:"status_emoji_display_info,omitempty"`
-	StatusExpiration       int                                 `json:"status_expiration"`
+	StatusExpiration       int                                 `json:"status_expiration,omitempty"`
 	Team                   string                              `json:"team"`
-	Fields                 UserProfileCustomFields             `json:"fields"`
+	Fields                 UserProfileCustomFields             `json:"fields,omitempty"`
 }
 
 type UserProfileStatusEmojiDisplayInfo struct {
@@ -130,6 +131,7 @@ type User struct {
 	IsAppUser         bool           `json:"is_app_user"`
 	IsInvitedUser     bool           `json:"is_invited_user"`
 	Has2FA            bool           `json:"has_2fa"`
+	TwoFactorType     *string        `json:"two_factor_type"`
 	HasFiles          bool           `json:"has_files"`
 	Presence          string         `json:"presence"`
 	Locale            string         `json:"locale"`
@@ -225,11 +227,13 @@ func (api *Client) userRequest(ctx context.Context, path string, values url.Valu
 }
 
 // GetUserPresence will retrieve the current presence status of given user.
+// For more information see the GetUserPresenceContext documentation.
 func (api *Client) GetUserPresence(user string) (*UserPresence, error) {
 	return api.GetUserPresenceContext(context.Background(), user)
 }
 
 // GetUserPresenceContext will retrieve the current presence status of given user with a custom context.
+// Slack API docs: https://api.slack.com/methods/users.getPresence
 func (api *Client) GetUserPresenceContext(ctx context.Context, user string) (*UserPresence, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -243,12 +247,14 @@ func (api *Client) GetUserPresenceContext(ctx context.Context, user string) (*Us
 	return &response.UserPresence, nil
 }
 
-// GetUserInfo will retrieve the complete user information
+// GetUserInfo will retrieve the complete user information.
+// For more information see the GetUserInfoContext documentation.
 func (api *Client) GetUserInfo(user string) (*User, error) {
 	return api.GetUserInfoContext(context.Background(), user)
 }
 
-// GetUserInfoContext will retrieve the complete user information with a custom context
+// GetUserInfoContext will retrieve the complete user information with a custom context.
+// Slack API docs: https://api.slack.com/methods/users.info
 func (api *Client) GetUserInfoContext(ctx context.Context, user string) (*User, error) {
 	values := url.Values{
 		"token":          {api.token},
@@ -263,12 +269,14 @@ func (api *Client) GetUserInfoContext(ctx context.Context, user string) (*User, 
 	return &response.User, nil
 }
 
-// GetUsersInfo will retrieve the complete multi-users information
+// GetUsersInfo will retrieve the complete multi-users information.
+// For more information see the GetUsersInfoContext documentation.
 func (api *Client) GetUsersInfo(users ...string) (*[]User, error) {
 	return api.GetUsersInfoContext(context.Background(), users...)
 }
 
-// GetUsersInfoContext will retrieve the complete multi-users information with a custom context
+// GetUsersInfoContext will retrieve the complete multi-users information with a custom context.
+// Slack API docs: https://api.slack.com/methods/users.info
 func (api *Client) GetUsersInfoContext(ctx context.Context, users ...string) (*[]User, error) {
 	values := url.Values{
 		"token":          {api.token},
@@ -405,12 +413,14 @@ func (api *Client) GetUsersContext(ctx context.Context, options ...GetUsersOptio
 	return results, p.Failure(err)
 }
 
-// GetUserByEmail will retrieve the complete user information by email
+// GetUserByEmail will retrieve the complete user information by email.
+// For more information see the GetUserByEmailContext documentation.
 func (api *Client) GetUserByEmail(email string) (*User, error) {
 	return api.GetUserByEmailContext(context.Background(), email)
 }
 
-// GetUserByEmailContext will retrieve the complete user information by email with a custom context
+// GetUserByEmailContext will retrieve the complete user information by email with a custom context.
+// Slack API docs: https://api.slack.com/methods/users.lookupByEmail
 func (api *Client) GetUserByEmailContext(ctx context.Context, email string) (*User, error) {
 	values := url.Values{
 		"token": {api.token},
@@ -423,12 +433,14 @@ func (api *Client) GetUserByEmailContext(ctx context.Context, email string) (*Us
 	return &response.User, nil
 }
 
-// SetUserAsActive marks the currently authenticated user as active
+// SetUserAsActive marks the currently authenticated user as active.
+// For more information see the SetUserAsActiveContext documentation.
 func (api *Client) SetUserAsActive() error {
 	return api.SetUserAsActiveContext(context.Background())
 }
 
-// SetUserAsActiveContext marks the currently authenticated user as active with a custom context
+// SetUserAsActiveContext marks the currently authenticated user as active with a custom context.
+// Slack API docs: https://api.slack.com/methods/users.setActive
 func (api *Client) SetUserAsActiveContext(ctx context.Context) (err error) {
 	values := url.Values{
 		"token": {api.token},
@@ -438,12 +450,14 @@ func (api *Client) SetUserAsActiveContext(ctx context.Context) (err error) {
 	return err
 }
 
-// SetUserPresence changes the currently authenticated user presence
+// SetUserPresence changes the currently authenticated user presence.
+// For more information see the SetUserPresenceContext documentation.
 func (api *Client) SetUserPresence(presence string) error {
 	return api.SetUserPresenceContext(context.Background(), presence)
 }
 
-// SetUserPresenceContext changes the currently authenticated user presence with a custom context
+// SetUserPresenceContext changes the currently authenticated user presence with a custom context.
+// Slack API docs: https://api.slack.com/methods/users.setPresence
 func (api *Client) SetUserPresenceContext(ctx context.Context, presence string) error {
 	values := url.Values{
 		"token":    {api.token},
@@ -454,12 +468,14 @@ func (api *Client) SetUserPresenceContext(ctx context.Context, presence string) 
 	return err
 }
 
-// GetUserIdentity will retrieve user info available per identity scopes
+// GetUserIdentity will retrieve user info available per identity scopes.
+// For more information see the GetUserIdentityContext documentation.
 func (api *Client) GetUserIdentity() (*UserIdentityResponse, error) {
 	return api.GetUserIdentityContext(context.Background())
 }
 
-// GetUserIdentityContext will retrieve user info available per identity scopes with a custom context
+// GetUserIdentityContext will retrieve user info available per identity scopes with a custom context.
+// Slack API docs: https://api.slack.com/methods/users.identity
 func (api *Client) GetUserIdentityContext(ctx context.Context) (response *UserIdentityResponse, err error) {
 	values := url.Values{
 		"token": {api.token},
@@ -478,12 +494,14 @@ func (api *Client) GetUserIdentityContext(ctx context.Context) (response *UserId
 	return response, nil
 }
 
-// SetUserPhoto changes the currently authenticated user's profile image
+// SetUserPhoto changes the currently authenticated user's profile image.
+// For more information see the SetUserPhotoContext documentation.
 func (api *Client) SetUserPhoto(image string, params UserSetPhotoParams) error {
 	return api.SetUserPhotoContext(context.Background(), image, params)
 }
 
-// SetUserPhotoContext changes the currently authenticated user's profile image using a custom context
+// SetUserPhotoContext changes the currently authenticated user's profile image using a custom context.
+// Slack API docs: https://api.slack.com/methods/users.setPhoto
 func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params UserSetPhotoParams) (err error) {
 	response := &SlackResponse{}
 	values := url.Values{}
@@ -505,12 +523,14 @@ func (api *Client) SetUserPhotoContext(ctx context.Context, image string, params
 	return response.Err()
 }
 
-// DeleteUserPhoto deletes the current authenticated user's profile image
+// DeleteUserPhoto deletes the current authenticated user's profile image.
+// For more information see the DeleteUserPhotoContext documentation.
 func (api *Client) DeleteUserPhoto() error {
 	return api.DeleteUserPhotoContext(context.Background())
 }
 
-// DeleteUserPhotoContext deletes the current authenticated user's profile image with a custom context
+// DeleteUserPhotoContext deletes the current authenticated user's profile image with a custom context.
+// Slack API docs: https://api.slack.com/methods/users.deletePhoto
 func (api *Client) DeleteUserPhotoContext(ctx context.Context) (err error) {
 	response := &SlackResponse{}
 	values := url.Values{
@@ -526,13 +546,13 @@ func (api *Client) DeleteUserPhotoContext(ctx context.Context) (err error) {
 }
 
 // SetUserRealName changes the currently authenticated user's realName
-//
-// For more information see SetUserRealNameContextWithUser
+// For more information see the SetUserRealNameContextWithUser documentation.
 func (api *Client) SetUserRealName(realName string) error {
 	return api.SetUserRealNameContextWithUser(context.Background(), "", realName)
 }
 
-// SetUserRealNameContextWithUser will set a real name for the provided user with a custom context
+// SetUserRealNameContextWithUser will set a real name for the provided user with a custom context.
+// Slack API docs: https://api.slack.com/methods/users.profile.set
 func (api *Client) SetUserRealNameContextWithUser(ctx context.Context, user, realName string) error {
 	profile, err := json.Marshal(
 		&struct {
@@ -564,20 +584,22 @@ func (api *Client) SetUserRealNameContextWithUser(ctx context.Context, user, rea
 	return response.Err()
 }
 
-// SetUserCustomFields sets Custom Profile fields on the provided users account.  Due to the non-repeating elements
-// within the request, a map fields is required.  The key in the map signifies the field that will be updated.
-//
-// Note: You may need to change the way the custom field is populated within the Profile section of the Admin Console from
-// SCIM or User Entered to API.
-//
-// See GetTeamProfile for information to retrieve possible fields for your account.
+// SetUserCustomFields sets Custom Profile fields on the provided users account.
+// For more information see the SetUserCustomFieldsContext documentation.
 func (api *Client) SetUserCustomFields(userID string, customFields map[string]UserProfileCustomField) error {
 	return api.SetUserCustomFieldsContext(context.Background(), userID, customFields)
 }
 
-// SetUserCustomFieldsContext will set a users custom profile field with context.
+// SetUserCustomFieldsContext sets Custom Profile fields on the provided users account.
+// Due to the non-repeating elements within the request, a map fields is required.
+// The key in the map signifies the field that will be updated.
 //
-// For more information see SetUserCustomFields
+// Note: You may need to change the way the custom field is populated within the Profile section of the Admin Console
+// from SCIM or User Entered to API.
+//
+// See GetTeamProfile for information to retrieve possible fields for your account.
+//
+// Slack API docs: https://api.slack.com/methods/users.profile.set
 func (api *Client) SetUserCustomFieldsContext(ctx context.Context, userID string, customFields map[string]UserProfileCustomField) error {
 
 	// Convert data to data type with custom marshall / unmarshall
@@ -613,32 +635,30 @@ func (api *Client) SetUserCustomFieldsContext(ctx context.Context, userID string
 
 }
 
-// SetUserCustomStatus will set a custom status and emoji for the currently
-// authenticated user. If statusEmoji is "" and statusText is not, the Slack API
-// will automatically set it to ":speech_balloon:". Otherwise, if both are ""
-// the Slack API will unset the custom status/emoji. If statusExpiration is set to 0
-// the status will not expire.
+// SetUserCustomStatus will set a custom status and emoji for the currently authenticated user.
+// For more information see the SetUserCustomStatusContext documentation.
 func (api *Client) SetUserCustomStatus(statusText, statusEmoji string, statusExpiration int64) error {
 	return api.SetUserCustomStatusContextWithUser(context.Background(), "", statusText, statusEmoji, statusExpiration)
 }
 
-// SetUserCustomStatusContext will set a custom status and emoji for the currently authenticated user with a custom context
-//
-// For more information see SetUserCustomStatus
+// SetUserCustomStatusContext will set a custom status and emoji for the currently authenticated user with a custom context.
+// For more information see the SetUserCustomStatusContextWithUser documentation.
 func (api *Client) SetUserCustomStatusContext(ctx context.Context, statusText, statusEmoji string, statusExpiration int64) error {
 	return api.SetUserCustomStatusContextWithUser(ctx, "", statusText, statusEmoji, statusExpiration)
 }
 
 // SetUserCustomStatusWithUser will set a custom status and emoji for the provided user.
-//
-// For more information see SetUserCustomStatus
+// For more information see the SetUserCustomStatusContextWithUser documentation.
 func (api *Client) SetUserCustomStatusWithUser(user, statusText, statusEmoji string, statusExpiration int64) error {
 	return api.SetUserCustomStatusContextWithUser(context.Background(), user, statusText, statusEmoji, statusExpiration)
 }
 
-// SetUserCustomStatusContextWithUser will set a custom status and emoji for the provided user with a custom context
+// SetUserCustomStatusContextWithUser will set a custom status and emoji for the currently authenticated user.
+// If statusEmoji is "" and statusText is not, the Slack API will automatically set it to ":speech_balloon:".
+// Otherwise, if both are "" the Slack API will unset the custom status/emoji. If statusExpiration is set to 0
+// the status will not expire.
 //
-// For more information see SetUserCustomStatus
+// Slack API docs: https://api.slack.com/methods/users.profile.set
 func (api *Client) SetUserCustomStatusContextWithUser(ctx context.Context, user, statusText, statusEmoji string, statusExpiration int64) error {
 	// XXX(theckman): this anonymous struct is for making requests to the Slack
 	// API for setting and unsetting a User's Custom Status/Emoji. To change
@@ -703,6 +723,7 @@ type GetUserProfileParameters struct {
 }
 
 // GetUserProfile retrieves a user's profile information.
+// For more information see the GetUserProfileContext documentation.
 func (api *Client) GetUserProfile(params *GetUserProfileParameters) (*UserProfile, error) {
 	return api.GetUserProfileContext(context.Background(), params)
 }
@@ -713,6 +734,7 @@ type getUserProfileResponse struct {
 }
 
 // GetUserProfileContext retrieves a user's profile information with a context.
+// Slack API docs: https://api.slack.com/methods/users.profile.get
 func (api *Client) GetUserProfileContext(ctx context.Context, params *GetUserProfileParameters) (*UserProfile, error) {
 	values := url.Values{"token": {api.token}}
 

--- a/vendor/github.com/slack-go/slack/views.go
+++ b/vendor/github.com/slack-go/slack/views.go
@@ -155,6 +155,7 @@ type ViewResponse struct {
 }
 
 // OpenView opens a view for a user.
+// For more information see the OpenViewContext documentation.
 func (api *Client) OpenView(triggerID string, view ModalViewRequest) (*ViewResponse, error) {
 	return api.OpenViewContext(context.Background(), triggerID, view)
 }
@@ -177,6 +178,7 @@ func ValidateUniqueBlockID(view ModalViewRequest) bool {
 }
 
 // OpenViewContext opens a view for a user with a custom context.
+// Slack API docs: https://api.slack.com/methods/views.open
 func (api *Client) OpenViewContext(
 	ctx context.Context,
 	triggerID string,
@@ -208,11 +210,13 @@ func (api *Client) OpenViewContext(
 }
 
 // PublishView publishes a static view for a user.
+// For more information see the PublishViewContext documentation.
 func (api *Client) PublishView(userID string, view HomeTabViewRequest, hash string) (*ViewResponse, error) {
 	return api.PublishViewContext(context.Background(), userID, view, hash)
 }
 
 // PublishViewContext publishes a static view for a user with a custom context.
+// Slack API docs: https://api.slack.com/methods/views.publish
 func (api *Client) PublishViewContext(
 	ctx context.Context,
 	userID string,
@@ -241,11 +245,13 @@ func (api *Client) PublishViewContext(
 }
 
 // PushView pushes a view onto the stack of a root view.
+// For more information see the PushViewContext documentation.
 func (api *Client) PushView(triggerID string, view ModalViewRequest) (*ViewResponse, error) {
 	return api.PushViewContext(context.Background(), triggerID, view)
 }
 
-// PublishViewContext pushes a view onto the stack of a root view with a custom context.
+// PushViewContext pushes a view onto the stack of a root view with a custom context.
+// Slack API docs: https://api.slack.com/methods/views.push
 func (api *Client) PushViewContext(
 	ctx context.Context,
 	triggerID string,
@@ -272,11 +278,13 @@ func (api *Client) PushViewContext(
 }
 
 // UpdateView updates an existing view.
+// For more information see the UpdateViewContext documentation.
 func (api *Client) UpdateView(view ModalViewRequest, externalID, hash, viewID string) (*ViewResponse, error) {
 	return api.UpdateViewContext(context.Background(), view, externalID, hash, viewID)
 }
 
 // UpdateViewContext updates an existing view with a custom context.
+// Slack API docs: https://api.slack.com/methods/views.update
 func (api *Client) UpdateViewContext(
 	ctx context.Context,
 	view ModalViewRequest,

--- a/vendor/github.com/slack-go/slack/webhooks.go
+++ b/vendor/github.com/slack-go/slack/webhooks.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -24,6 +23,8 @@ type WebhookMessage struct {
 	ReplaceOriginal bool         `json:"replace_original"`
 	DeleteOriginal  bool         `json:"delete_original"`
 	ReplyBroadcast  bool         `json:"reply_broadcast,omitempty"`
+	UnfurlLinks     bool         `json:"unfurl_links,omitempty"`
+	UnfurlMedia     bool         `json:"unfurl_media,omitempty"`
 }
 
 func PostWebhook(url string, msg *WebhookMessage) error {
@@ -55,7 +56,7 @@ func PostWebhookCustomHTTPContext(ctx context.Context, url string, httpClient *h
 		return fmt.Errorf("failed to post webhook: %w", err)
 	}
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}()
 

--- a/vendor/github.com/slack-go/slack/workflow_step.go
+++ b/vendor/github.com/slack-go/slack/workflow_step.go
@@ -44,12 +44,15 @@ func NewConfigurationModalRequest(blocks Blocks, privateMetaData string, externa
 	}
 }
 
+// SaveWorkflowStepConfiguration opens a configuration modal for a workflow step.
+// For more information see the SaveWorkflowStepConfigurationContext documentation.
 func (api *Client) SaveWorkflowStepConfiguration(workflowStepEditID string, inputs *WorkflowStepInputs, outputs *[]WorkflowStepOutput) error {
 	return api.SaveWorkflowStepConfigurationContext(context.Background(), workflowStepEditID, inputs, outputs)
 }
 
+// SaveWorkflowStepConfigurationContext saves the configuration of a workflow step with a custom context.
+// Slack API docs: https://api.slack.com/methods/workflows.updateStep
 func (api *Client) SaveWorkflowStepConfigurationContext(ctx context.Context, workflowStepEditID string, inputs *WorkflowStepInputs, outputs *[]WorkflowStepOutput) error {
-	// More information: https://api.slack.com/methods/workflows.updateStep
 	wscr := WorkflowStepCompleteResponse{
 		WorkflowStepEditID: workflowStepEditID,
 		Inputs:             inputs,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1254,7 +1254,7 @@ github.com/sirupsen/logrus
 # github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 ## explicit
 github.com/skratchdot/open-golang/open
-# github.com/slack-go/slack v0.12.1
+# github.com/slack-go/slack v0.15.0
 ## explicit; go 1.16
 github.com/slack-go/slack
 github.com/slack-go/slack/internal/backoff


### PR DESCRIPTION
Bump the slack library to the latest version and use `UploadFileV2`, which replaces the deprecated and soon to be unsupported `UploadFile`.