### PR TITLE
Fix the default release version for master branch PR

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -92,7 +92,7 @@ const (
 
 var CurrentRelease = semver.Version{
 	Major: 4,
-	Minor: 17,
+	Minor: 18,
 }
 
 var HypershiftSupportedVersions = HypershiftSupportedVersionsType{}


### PR DESCRIPTION
If users do not explicitly specify 4.18 for master branch PRs (e.g. `launch openshift/cluster-authentication-operator#713,openshift/cluster-kube-apiserver-operator#1760`), the cluster-bot launched cluster always hit installation failure. Checked the cluster-bot's build, it is prefixed with 4.17.0 like 4.17.0-0.ci.test-2024-11-11-050813-ci-ln-wqp6qzk-latest. This PR fixes it due to https://github.com/openshift/ci-chat-bot/blob/master/pkg/manager/manager.go uses it as below:
```
	if refs.BaseRef == "master" || refs.BaseRef == "main" {
		return fmt.Sprintf("%d.%d.0-0.latest", CurrentRelease.Major, CurrentRelease.Minor)
	}
```
@bradmwilliams could you help review/merge? Thx!