### PR TITLE
Parse trailing parameters with whitespaces

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -39,6 +39,10 @@
 
    `workflow-launch openshift-e2e-azure 4.18 "SIZE_VARIANT=compact","OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP=1"`
 
+   The parameters can also be space separated, for example in the case of capabilities:
+ 
+   `workflow-launch openshift-e2e-gcp 4.18 "BASELINE_CAPABILITY_SET=None","ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI"`
+
    To add a workflow to be supported by the command, the workflow must be added to the workflow config file via a PR to `openshift/release`. For most workflows, only the following will need to be added:
    ```
    workflow_name:

--- a/pkg/slack/parser/commandParser.go
+++ b/pkg/slack/parser/commandParser.go
@@ -11,14 +11,14 @@ import (
 
 const (
 	escapeCharacter      = "\\"
-	ignoreCase           = "(?i)"
+	ignoreCase           = "(?iU)"
 	parameterPattern     = "<\\S+>"
 	lazyParameterPattern = "<\\S+\\?>"
 	spacePattern         = "\\s+"
 	inputPattern         = "(.+)"
 	lazyInputPattern     = "(.+?)"
 	preCommandPattern    = "(^)"
-	postCommandPattern   = "(\\s|$)"
+	postCommandPattern   = "$"
 )
 
 const (
@@ -176,7 +176,7 @@ func (c *Command) Match(text string) (*Properties, bool) {
 			continue
 		}
 
-		values := matches[2 : len(matches)-1]
+		values := matches[2:]
 
 		valueIndex := 0
 		parameters := make(map[string]string)

--- a/pkg/slack/parser/commandParser_test.go
+++ b/pkg/slack/parser/commandParser_test.go
@@ -59,6 +59,11 @@ var supportedCommands = []BotCommand{
 		Example:     "catalog build openshift/aws-efs-csi-driver-operator#75 aws-efs-csi-driver-operator-bundle",
 		Handler:     emptyHandler,
 	}, false),
+	NewBotCommand("workflow-launch <name> <image_or_version_or_prs> <parameters>", &CommandDefinition{
+		Description: "Launch a cluster using the requested workflow from an image or release or built PRs. The from argument may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org.",
+		Example:     "workflow-launch openshift-e2e-gcp-windows-node 4.18 gcp",
+		Handler:     emptyHandler,
+	}, false),
 }
 
 func codeSlice(items []string) []string {
@@ -200,6 +205,16 @@ func TestMatch(t *testing.T) {
 			PropertyMap: map[string]string{
 				"pullrequest": "openshift/aws-efs-csi-driver-operator#75",
 				"bundle_name": "aws-efs-csi-driver-operator-bundle",
+			},
+		},
+	}, {
+		command: "workflow-launch openshift-e2e-gcp 4.18 \"BASELINE_CAPABILITY_SET=None\",\"ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI\"",
+		match:   9,
+		properties: &Properties{
+			PropertyMap: map[string]string{
+				"name":                    "openshift-e2e-gcp",
+				"image_or_version_or_prs": "4.18",
+				"parameters":              "\"BASELINE_CAPABILITY_SET=None\",\"ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI\"",
 			},
 		},
 	}}


### PR DESCRIPTION
To provide capabilities as workflow parameters the parser needs to be adjusted to handle the group matching based on trailing whitespaces.

This changes the parser to lazily match the sequence until the very end of the message and not until the last whitespace to capture the right groups.