### PR TITLE
add private parameter

### DIFF
--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -56,7 +56,7 @@ var SupportedUpgradeTests = []string{"e2e-upgrade", "e2e-upgrade-all", "e2e-upgr
 var SupportedPlatforms = []string{"aws", "gcp", "azure", "vsphere", "metal", "ovirt", "openstack", "hypershift-hosted", "nutanix", "alibaba", "hypershift-hosted-powervs", "azure-stackhub"}
 
 // SupportedParameters are the allowed parameter keys that can be passed to jobs
-var SupportedParameters = []string{"ovn", "ovn-hybrid", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv4", "ipv6", "dualstack", "dualstack-primaryv6", "preserve-bootstrap", "test", "rt", "single-node", "cgroupsv2", "techpreview", "upi", "crun", "nfv", "kuryr", "sdn", "no-spot", "no-capabilities", "virtualization-support", "multi-zone", "multi-zone-techpreview", "bundle"}
+var SupportedParameters = []string{"ovn", "ovn-hybrid", "proxy", "compact", "fips", "mirror", "shared-vpc", "large", "xlarge", "ipv4", "ipv6", "dualstack", "dualstack-primaryv6", "preserve-bootstrap", "test", "rt", "single-node", "cgroupsv2", "techpreview", "upi", "crun", "nfv", "kuryr", "sdn", "no-spot", "no-capabilities", "virtualization-support", "multi-zone", "multi-zone-techpreview", "bundle", "private"}
 
 // MultistageParameters is the mapping of SupportedParameters that can be configured via multistage parameters to the correct environment variable format
 var MultistageParameters = map[string]EnvVar{


### PR DESCRIPTION
There is no private option for launch command, so add it. @sunzhaohua2 @miyadav @shellyyang1989 @bradmwilliams PTAL, thanks!

```
Huali Liu
  9:33 AM
launch 4.18,openshift/cloud-provider-gcp#72 gcp,proxy,private
Cluster Bot
APP  9:33 AM
unrecognized option: private
```