### PR TITLE
OCPCRT-360:  pass values to DEVSCRIPTS_CONFIG_CLUSTERBOT to support overrides

### DIFF
--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -43,6 +43,24 @@ func TestBuildJobParams(t *testing.T) {
 			expected:    map[string]string{"KEY1": "VALUE1"},
 			errorString: "",
 		},
+		{
+			name:        "One DEVSCRIPTSParameter",
+			params:      "\"DEVSCRIPTS_CONFIG_CLUSTERBOT=KEY1=VALUE1\"",
+			expected:    map[string]string{"DEVSCRIPTS_CONFIG_CLUSTERBOT": "KEY1=VALUE1"},
+			errorString: "",
+		},
+		{
+			name:        "Two DEVSCRIPTSParameters",
+			params:      "\"DEVSCRIPTS_CONFIG_CLUSTERBOT=KEY1=VALUE1\\nKEY2=VALUE2\"",
+			expected:    map[string]string{"DEVSCRIPTS_CONFIG_CLUSTERBOT": "KEY1=VALUE1 KEY2=VALUE2"},
+			errorString: "",
+		},
+		{
+			name:        "DEVSCRIPTSParametersBad",
+			params:      "\"DEVSCRIPTS_CONFIG_CLUSTERBOT=KEY1=VALUE1,KEY2=VALUE2\"",
+			expected:    nil,
+			errorString: "unable to interpret `DEVSCRIPTS_CONFIG_CLUSTERBOT=KEY1=VALUE1,KEY2=VALUE2` as a parameter. Please ensure that parameters are separated by newlines",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The `DEVSCRIPTS_CONFIG` variable is used to pass an array of `key=value` pairs to [some code](https://github.com/openshift/release/blob/7c9e17caab51f23303d648a5f2f491f770c72c35/ci-operator/step-registry/baremetalds/devscripts/setup/baremetalds-devscripts-setup-commands.sh#L171-L178) that extracts those `key=value` pairs as environment variables.

Since we cannot pass an array from a clusterbot command line to the prow job that creates the Openshift cluster, we pass a separate space-separated list of `key=value` pairs.

This PR introduces that space-separated list in a variable called `DEVSCRIPTS_CONFIG_CLUSTERBOT`. For example, in the clusterbot app, you can say: `workflow-launch cucushift-installer-rehearse-baremetalds-ipi-ovn 4.19 "DEVSCRIPTS_CONFIG_CLUSTERBOT=INSTALLER_PROXY=true\nIP_STACK=v4\nNETWORK_TYPE=OVNKubernetes`.

Because we introduce a new variable, we need this [release PR](https://github.com/openshift/release/pull/60930) to merged first. 