### PR TITLE
Support nested parameter (e.g., DEVSCRIPTS_CONFIG) injection from clusterbot

### DIFF
--- a/pkg/slack/slack_test.go
+++ b/pkg/slack/slack_test.go
@@ -43,6 +43,36 @@ func TestBuildJobParams(t *testing.T) {
 			expected:    map[string]string{"KEY1": "VALUE1"},
 			errorString: "",
 		},
+		{
+			name:        "SingleNESTED_PARAMETER",
+			params:      "\"NESTED_PARAMETER=KEY1=VALUE1\"",
+			expected:    map[string]string{"NESTED_PARAMETER": "KEY1=VALUE1"},
+			errorString: "",
+		},
+		{
+			name:        "MultipleNESTED_PARAMETERs",
+			params:      "\"NESTED_PARAMETER=KEY1=VALUE1;KEY2=VALUE2\"",
+			expected:    map[string]string{"NESTED_PARAMETER": "KEY1=VALUE1\nKEY2=VALUE2"},
+			errorString: "",
+		},
+		{
+			name:        "MixedParametersWithNESTED_PARAMETERs",
+			params:      "\"BASELINE_CAPABILITY_SET=None\",\"NESTED_PARAMETER=KEY1=VALUE1;KEY2=VALUE2\"",
+			expected:    map[string]string{"BASELINE_CAPABILITY_SET": "None", "NESTED_PARAMETER": "KEY1=VALUE1\nKEY2=VALUE2"},
+			errorString: "",
+		},
+		{
+			name:        "MultipleMixedParameters",
+			params:      "\"BASELINE_CAPABILITY_SET=None\",\"NESTED_PARAMETER=KEY1=VALUE1;KEY2=VALUE2\",\"OTHER_CONFIG=KEY1=VALUE1a;KEY2=VALUE2a\"",
+			expected:    map[string]string{"BASELINE_CAPABILITY_SET": "None", "NESTED_PARAMETER": "KEY1=VALUE1\nKEY2=VALUE2", "OTHER_CONFIG": "KEY1=VALUE1a\nKEY2=VALUE2a"},
+			errorString: "",
+		},
+		{
+			name:        "InvalidMixedParameters",
+			params:      "\"BASELINE_CAPABILITY_SET=None\",\"NESTED_PARAMETER=KEY1=VALUE1;KEY2;KEY3=VALUE3\",\"OTHER_CONFIG=KEY1=VALUE1a;KEY2=VALUE2a\"",
+			expected:    nil,
+			errorString: "unable to interpret parameter in `KEY2`. Each nested parameter must be in the form of KEY=VALUE",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This allows injecting values for the `DEVSCRIPTS_CONFIG` variable (used in metal tests).

The values must be separated by a `;` e.g.:

```
workflow-launch cucushift-installer-rehearse-baremetalds-ipi-ovn 4.19 "DEVSCRIPTS_CONFIG=INSTALLER_PROXY=true;IP_STACK=v4;NETWORK_TYPE=OVNKubernetes;DENNIS_FOO=BAR"
```

The key is not limited to `DEVSCRIPTS_CONFIG`, e.g:

```
workflow-launch cucushift-installer-rehearse-baremetalds-ipi-ovn 4.19 "FOO_CONFIG=INSTALLER_PROXY=true;IP_STACK=v4;NETWORK_TYPE=OVNKubernetes;DENNIS_FOO=BAR"
```

Here's an example [prow job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-metal/1882844664378167296) showing the [variables are properly added](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/release-openshift-origin-installer-launch-metal/1882844664378167296/artifacts/launch/baremetalds-devscripts-setup/artifacts/root/dev-scripts/logs/01_install_requirements-2025-01-24-174550.log) (search for `export DENNIS_FOO=BAR` and see the variables before that).