### PR TITLE
manager: support nightlies and image builds for MCE

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -749,9 +749,9 @@ func (m *jobManager) sync() error {
 			}
 			m.mceClusters.lock.RLock()
 			if mCluster, ok := m.mceClusters.clusters[j.ManagedClusterName]; ok {
-				errMsg := fmt.Sprintf("Failed to generate imageset for managed cluster. See logs for details: %s", job.Status.URL)
+				errMsg := fmt.Sprintf("Failed to generate imageset for managed cluster. See logs for details: %s.", job.Status.URL)
 				if err := m.deleteManagedCluster(mCluster); err != nil {
-					errMsg = fmt.Sprintf(" An error also occurred when attempting to delete the previously created resources: %v", err)
+					errMsg = fmt.Sprintf("\nAn error also occurred when attempting to delete the previously created resources: %v", err)
 					klog.Errorf("Failed to delete managed cluster %s: %v", j.ManagedClusterName, err)
 				}
 				go m.mceSync() // nolint:errcheck
@@ -780,7 +780,7 @@ func (m *jobManager) sync() error {
 						msg := fmt.Sprintf("Could not identify ci-operator namespace for job %s.", job.Name)
 						klog.Error(msg)
 						if err := m.deleteManagedCluster(mCluster); err != nil {
-							msg += fmt.Sprintf(" An error also occurred when attempting to delete the previously created resources: %v", err)
+							msg += fmt.Sprintf("\nAn error also occurred when attempting to delete the previously created resources: %v", err)
 							klog.Errorf("Failed to delete managed cluster %s: %v", j.ManagedClusterName, err)
 						}
 						go m.mceSync() // nolint:errcheck
@@ -790,10 +790,10 @@ func (m *jobManager) sync() error {
 					}
 					registryURL := fmt.Sprintf("registry.%s.ci.openshift.org/%s/release:latest", j.BuildCluster, ciOpNamespace)
 					if err := m.createCustomImageset(registryURL, j.ManagedClusterName); err != nil {
-						msg := fmt.Sprintf("Failed to create imageset for release created by ci-operator: %v", err)
+						msg := fmt.Sprintf("Failed to create imageset for release created by ci-operator: %v.", err)
 						klog.Errorf("Failed to create cluster imageset: %v", err)
 						if err := m.deleteManagedCluster(mCluster); err != nil {
-							msg += fmt.Sprintf(" An error also occurred when attempting to delete the previously created resources: %v", err)
+							msg += fmt.Sprintf("\nAn error also occurred when attempting to delete the previously created resources: %v", err)
 							klog.Errorf("Failed to delete managed cluster %s: %v", j.ManagedClusterName, err)
 						}
 						go m.mceSync() // nolint:errcheck
@@ -813,7 +813,7 @@ func (m *jobManager) sync() error {
 						msg := fmt.Sprintf("Failed to create Cluster Deployment: %v", err)
 						klog.Errorf("Failed to create cluster deployment: %v", err)
 						if err := m.deleteManagedCluster(mCluster); err != nil {
-							msg += fmt.Sprintf(" An error also occurred when attempting to delete the previously created resources: %v", err)
+							msg += fmt.Sprintf("\nAn error also occurred when attempting to delete the previously created resources: %v", err)
 							klog.Errorf("Failed to delete managed cluster %s: %v", j.ManagedClusterName, err)
 						}
 						go m.mceSync() // nolint:errcheck
@@ -835,7 +835,7 @@ func (m *jobManager) sync() error {
 					// Check if the user has an existing request.  If they do, then move on
 					if _, ok := m.requests[user]; !ok {
 						// If not, then most likely, the clusterbot has recently (re)started, and we need to populate the
-						// request to ensure that the user can't start a second cluster (instead of aiting for the second
+						// request to ensure that the user can't start a second cluster (instead of waiting for the second
 						// invocation of the sync loop to populate it accordingly).
 						// The 2 scenarios where we need to handle populating the request entry are:
 						//  * A new request (i.e. there is no "previous" job for this user)

--- a/pkg/manager/mce.go
+++ b/pkg/manager/mce.go
@@ -240,7 +240,7 @@ func (m *jobManager) createManagedCluster(imageSet, platform, user, slackChannel
 		return nil, fmt.Errorf("failed to create managed cluster object: %v", err)
 	}
 
-	// if the user requerted a release that exists as GA, we can start deployment immediately
+	// if the user requested a release that exists as GA, we can start deployment immediately
 	if req == nil {
 		if err := m.createClusterDeployment(clusterName, imageSet, baseDomain, platform); err != nil {
 			return nil, err

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -268,7 +268,8 @@ type JobRequest struct {
 	JobName   string
 	JobParams map[string]string
 
-	Architecture string
+	Architecture       string
+	ManagedClusterName string
 }
 
 type JobType string
@@ -295,7 +296,7 @@ type JobManager interface {
 	ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion, architecture string) (string, string, string, error)
 	ResolveAsPullRequest(spec string) (*prowapiv1.Refs, error)
 
-	CreateMceCluster(user, channel, platform, imageset string, duration time.Duration) (string, error)
+	CreateMceCluster(user, channel, platform string, from [][]string, duration time.Duration) (string, error)
 	DeleteMceCluster(user, clusterName string) (string, error)
 	GetManagedClustersForUser(user string) (map[string]*clusterv1.ManagedCluster, map[string]*hivev1.ClusterDeployment, map[string]*hivev1.ClusterProvision, map[string]string, map[string]string)
 	ListManagedClusters(user string) string
@@ -313,7 +314,7 @@ type RosaCallbackFunc func(*clustermgmtv1.Cluster, string)
 
 // RosaCallbackFunc is invoked when the rosa cluster changes state in a significant
 // way. Takes the ManagedCluster object, kubeconfig, and admin password.
-type MCECallbackFunc func(*clusterv1.ManagedCluster, *hivev1.ClusterDeployment, *hivev1.ClusterProvision, string, string)
+type MCECallbackFunc func(*clusterv1.ManagedCluster, *hivev1.ClusterDeployment, *hivev1.ClusterProvision, string, string, error)
 
 // JobInput defines the input to a job. Different modes need different inputs.
 type JobInput struct {
@@ -365,6 +366,8 @@ type Job struct {
 	Operator        OperatorInfo
 	CatalogComplete bool
 	CatalogError    bool
+
+	ManagedClusterName string
 }
 
 type OperatorInfo struct {

--- a/pkg/slack/actions.go
+++ b/pkg/slack/actions.go
@@ -109,7 +109,7 @@ func MceAuth(client *slack.Client, jobManager manager.JobManager, event *slackev
 	if _, ok := managed[name]; !ok {
 		return fmt.Sprintf("No cluster called `%s` for your user found", name)
 	}
-	NotifyMce(client, managed[name], deployments[name], provisions[name], kubeconfigs[name], passwords[name])
+	NotifyMce(client, managed[name], deployments[name], provisions[name], kubeconfigs[name], passwords[name], nil)
 	return " "
 }
 
@@ -507,16 +507,13 @@ func RosaDescribe(client *slack.Client, jobManager manager.JobManager, event *sl
 }
 
 func MceCreate(client *slack.Client, jobManager manager.JobManager, event *slackevents.MessageEvent, properties *parser.Properties) string {
-	from, err := ParseImageInput(properties.StringParam("version", ""))
+	from, err := ParseImageInput(properties.StringParam("image_or_version_or_prs", ""))
 	if err != nil {
 		return err.Error()
 	}
-	providedImageset := ""
-	if len(from) > 1 {
-		return "mce create only takes one version"
-	}
-	if len(from) == 1 {
-		providedImageset = from[0]
+	var inputs [][]string
+	if len(from) > 0 {
+		inputs = [][]string{from}
 	}
 
 	platformInput, err := ParseImageInput(properties.StringParam("platform", ""))
@@ -543,7 +540,7 @@ func MceCreate(client *slack.Client, jobManager manager.JobManager, event *slack
 		}
 	}
 
-	msg, err := jobManager.CreateMceCluster(event.User, event.Channel, platform, providedImageset, duration)
+	msg, err := jobManager.CreateMceCluster(event.User, event.Channel, platform, inputs, duration)
 	if err != nil {
 		return err.Error()
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,11 +20,13 @@ import (
 
 var LaunchLabel = "ci-chat-bot.openshift.io/launch"
 
+const BaseDomain = "ci-chat-bot/base-domain"
 const CoreOSURL = "https://coreos.slack.com"
 const UserTag = "ci-chat-bot/user"
 const ChannelTag = "ci-chat-bot/channel"
 const ExpiryTimeTag = "ci-chat-bot/expiry-time"
 const RequestTimeTag = "ci-chat-bot/request-time"
+const CustomImageTag = "ci-chat-bot/custom-image"
 
 type BuildClusterClientConfig struct {
 	CoreConfig        *rest.Config


### PR DESCRIPTION
This PR adds support for using prowjobs to create images pointing to nightlies or built from PRs that are able to be pulled without authentication using the `ipi-install-rbac` multistage test step. When a nightly or image build is requested, a prowjob is started to build the image and run the required step, and once it is complete, an imageset pointing to the release is created and a `ClusterDeployment` pointing to the imageset is created for the corresponding `ManagedCluster`. If an error occurs during the prow step, the user is sent an error message and the existing MCE resources are deleted.