### PR TITLE
Bumping default version to 4.19

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -35,13 +35,13 @@
 
    `workflow-launch {workflow_name} {image_or_version_or_prs} {parameters}`
 
-   The parameters option in the slack command is a list of double-quoted environment variable settings separated by commas. For instance, if I want to launch a 4.18 cluster using the openshift-e2e-azure workflow with a compact cluster size and preserved bootstrap resources, I would run this command:
+   The parameters option in the slack command is a list of double-quoted environment variable settings separated by commas. For instance, if I want to launch a 4.19 cluster using the openshift-e2e-azure workflow with a compact cluster size and preserved bootstrap resources, I would run this command:
 
-   `workflow-launch openshift-e2e-azure 4.18 "SIZE_VARIANT=compact","OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP=1"`
+   `workflow-launch openshift-e2e-azure 4.19 "SIZE_VARIANT=compact","OPENSHIFT_INSTALL_PRESERVE_BOOTSTRAP=1"`
 
    The parameters can also be space separated, for example in the case of capabilities:
  
-   `workflow-launch openshift-e2e-gcp 4.18 "BASELINE_CAPABILITY_SET=None","ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI"`
+   `workflow-launch openshift-e2e-gcp 4.19 "BASELINE_CAPABILITY_SET=None","ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI"`
 
    The parameters can have "nested parameters". When you want a parameter to contain multiple parameters, we need to nest them. To do this, set
    a parameter equal to a semi-colon separated list of parameters. For example:
@@ -63,7 +63,7 @@
 
    Here's an example of a nested parameter in a workflow:
 
-   `workflow-launch openshift-e2e-gcp 4.18 "BASELINE_CAPABILITY_SET=None","ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI","DEVSCRIPTS_CONFIG=AGENT_E2E_TEST_SCENARIO=HA_IPV4V6_DHCP;MIRROR_IMAGES=true"`
+   `workflow-launch openshift-e2e-gcp 4.19 "BASELINE_CAPABILITY_SET=None","ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI","DEVSCRIPTS_CONFIG=AGENT_E2E_TEST_SCENARIO=HA_IPV4V6_DHCP;MIRROR_IMAGES=true"`
 
    To add a workflow to be supported by the command, the workflow must be added to the workflow config file via a PR to `openshift/release`. For most workflows, only the following will need to be added:
    ```

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1487,7 +1487,7 @@ func (m *jobManager) lookupInputs(inputs [][]string, architecture string) ([]Job
 					return nil, defaultedVersion, fmt.Errorf("only one image or version may be specified in a list of installs")
 				}
 				if architecture == "arm64" && (len(runImage) == 0 || len(version) == 0) {
-					return nil, defaultedVersion, fmt.Errorf("only version numbers (like: 4.18.0) may be used for arm64 based clusters")
+					return nil, defaultedVersion, fmt.Errorf("only version numbers (like: 4.19.0) may be used for arm64 based clusters")
 				}
 				jobInput.Image = image
 				jobInput.Version = version
@@ -2088,7 +2088,7 @@ func (m *jobManager) LaunchJobForUser(req *JobRequest) (string, error) {
 		msg = fmt.Sprintf("%s This has the advantage of much faster startup times and lower costs.", msg)
 		msg = fmt.Sprintf("%s However, if you are testing specific functionality relating to the control plane in the release version you provided or you require", msg)
 		msg = fmt.Sprintf("%s multiple worker nodes, please end abort this launch with `done` and launch a cluster using another platform such as `aws` or `gcp`", msg)
-		msg = fmt.Sprintf("%s (e.g. `launch 4.18 aws`).\n\n", msg)
+		msg = fmt.Sprintf("%s (e.g. `launch 4.19 aws`).\n\n", msg)
 	}
 
 	if job.Mode == JobTypeLaunch || job.Mode == JobTypeWorkflowLaunch {

--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -602,7 +602,7 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 					Product:      "ocp",
 				},
 				Stream:  "nightly",
-				Version: "4.18",
+				Version: "4.19",
 			},
 		}
 	}
@@ -1551,7 +1551,7 @@ const permissionsScript = `
 # prow doesn't allow init containers or a second container
 export PATH=$PATH:/tmp/bin
 mkdir /tmp/bin
-curl -sL https://mirror.openshift.com/pub/openshift-v4/$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/clients/ocp/4.17.0/openshift-client-linux.tar.gz | tar xvzf - -C /tmp/bin/ oc
+curl -sL https://mirror.openshift.com/pub/openshift-v4/$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/clients/ocp/4.18.0/openshift-client-linux.tar.gz | tar xvzf - -C /tmp/bin/ oc
 chmod ug+x /tmp/bin/oc
 
 # grant all authenticated users access to the images in this namespace

--- a/pkg/manager/prow_test.go
+++ b/pkg/manager/prow_test.go
@@ -58,7 +58,7 @@ func Test_processOperatorPR(t *testing.T) {
 			},
 			InputConfiguration: citools.InputConfiguration{
 				BuildRootImage: &citools.BuildRootImageConfiguration{FromRepository: true},
-				BaseImages:     map[string]citools.ImageStreamTagReference{"an-image": {Namespace: "ci", Name: "test-image", Tag: "4.18"}},
+				BaseImages:     map[string]citools.ImageStreamTagReference{"an-image": {Namespace: "ci", Name: "test-image", Tag: "4.19"}},
 			},
 			Images: []citools.ProjectDirectoryImageBuildStepConfiguration{{
 				From: "base",
@@ -126,7 +126,7 @@ func Test_processOperatorPR(t *testing.T) {
 			InputConfiguration: citools.InputConfiguration{
 				BuildRootImage: &citools.BuildRootImageConfiguration{FromRepository: true},
 				BaseImages: map[string]citools.ImageStreamTagReference{
-					"an-image":    {Namespace: "ci", Name: "test-image", Tag: "4.18"},
+					"an-image":    {Namespace: "ci", Name: "test-image", Tag: "4.19"},
 					"my-operator": {Namespace: "$(NAMESPACE)", Name: "stable", Tag: "my-operator"},
 				},
 			},
@@ -165,7 +165,7 @@ func Test_processOperatorPR(t *testing.T) {
 			},
 			InputConfiguration: citools.InputConfiguration{
 				BuildRootImage: &citools.BuildRootImageConfiguration{FromRepository: true},
-				BaseImages:     map[string]citools.ImageStreamTagReference{"an-image": {Namespace: "ci", Name: "test-image", Tag: "4.18"}},
+				BaseImages:     map[string]citools.ImageStreamTagReference{"an-image": {Namespace: "ci", Name: "test-image", Tag: "4.19"}},
 			},
 			Images: []citools.ProjectDirectoryImageBuildStepConfiguration{{
 				From: "base",
@@ -210,7 +210,7 @@ func Test_processOperatorPR(t *testing.T) {
 			InputConfiguration: citools.InputConfiguration{
 				BuildRootImage: &citools.BuildRootImageConfiguration{FromRepository: true},
 				BaseImages: map[string]citools.ImageStreamTagReference{
-					"an-image":    {Namespace: "ci", Name: "test-image", Tag: "4.18"},
+					"an-image":    {Namespace: "ci", Name: "test-image", Tag: "4.19"},
 					"my-operator": {Namespace: "$(NAMESPACE)", Name: "stable", Tag: "my-operator"},
 				},
 			},

--- a/pkg/slack/parser/commandParser_test.go
+++ b/pkg/slack/parser/commandParser_test.go
@@ -13,21 +13,21 @@ import (
 // this is a partial copy of pkg/slack/slack.go
 var supportedCommands = []BotCommand{
 	NewBotCommand("launch <image_or_version_or_prs> <options>", &CommandDefinition{
-		Description: fmt.Sprintf("Launch an OpenShift cluster using a known image, version, or PR(s). You may omit both arguments. Arguments can be specified as any number of comma-delimited values. Use `nightly` for the latest OCP build, `ci` for the the latest CI build, provide a version directly from any listed on https://amd64.ocp.releases.ci.openshift.org, a stream name (4.18.0-0.ci, 4.18.0-0.nightly, etc), a major/minor `X.Y` to load the \"next stable\" version, from nightly, for that version (`4.18`), `<org>/<repo>#<pr>` to launch from any combination of PRs, or an image for the first argument. Options is a comma-delimited list of variations including platform (%s), architecture (%s), and variant (%s).",
+		Description: fmt.Sprintf("Launch an OpenShift cluster using a known image, version, or PR(s). You may omit both arguments. Arguments can be specified as any number of comma-delimited values. Use `nightly` for the latest OCP build, `ci` for the the latest CI build, provide a version directly from any listed on https://amd64.ocp.releases.ci.openshift.org, a stream name (4.19.0-0.ci, 4.19.0-0.nightly, etc), a major/minor `X.Y` to load the \"next stable\" version, from nightly, for that version (`4.19`), `<org>/<repo>#<pr>` to launch from any combination of PRs, or an image for the first argument. Options is a comma-delimited list of variations including platform (%s), architecture (%s), and variant (%s).",
 			strings.Join(codeSlice(manager.SupportedPlatforms), ", "),
 			strings.Join(codeSlice(manager.SupportedArchitectures), ", "),
 			strings.Join(codeSlice(manager.SupportedParameters), ", ")),
-		Example: "launch 4.18,openshift/installer#7160,openshift/machine-config-operator#3688 gcp,techpreview",
+		Example: "launch 4.19,openshift/installer#7160,openshift/machine-config-operator#3688 gcp,techpreview",
 		Handler: emptyHandler,
 	}, false),
 	NewBotCommand("rosa create <version> <duration>", &CommandDefinition{
 		Description: "Launch an cluster in ROSA. Only GA Openshift versions are supported at the moment.",
-		Example:     "rosa create 4.18 3h",
+		Example:     "rosa create 4.19 3h",
 		Handler:     emptyHandler,
 	}, false),
 	NewBotCommand("rosa lookup <version>", &CommandDefinition{
 		Description: "Find openshift version(s) with provided prefix that is supported in ROSA.",
-		Example:     "rosa lookup 4.18",
+		Example:     "rosa lookup 4.19",
 		Handler:     emptyHandler,
 	}, false),
 	NewBotCommand("list", &CommandDefinition{
@@ -36,12 +36,12 @@ var supportedCommands = []BotCommand{
 	}, false),
 	NewBotCommand("test upgrade <from> <to> <options>", &CommandDefinition{
 		Description: fmt.Sprintf("Run the upgrade tests between two release images. The arguments may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org. You may change the upgrade test by passing `test=NAME` in options with one of %s", strings.Join(codeSlice(manager.SupportedUpgradeTests), ", ")),
-		Example:     "test upgrade 4.17 4.18 aws",
+		Example:     "test upgrade 4.17 4.19 aws",
 		Handler:     emptyHandler,
 	}, false),
 	NewBotCommand("test <name> <image_or_version_or_prs> <options>", &CommandDefinition{
 		Description: fmt.Sprintf("Run the requested test suite from an image or release or built PRs. Supported test suites are %s. The from argument may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org. ", strings.Join(codeSlice(manager.SupportedTests), ", ")),
-		Example:     "test e2e 4.18 vsphere",
+		Example:     "test e2e 4.19 vsphere",
 		Handler:     emptyHandler,
 	}, false),
 	NewBotCommand("build <pullrequest>", &CommandDefinition{
@@ -51,7 +51,7 @@ var supportedCommands = []BotCommand{
 	}, false),
 	NewBotCommand("lookup <image_or_version_or_prs> <architecture>", &CommandDefinition{
 		Description: "Get info about a version.",
-		Example:     "lookup 4.18 arm64",
+		Example:     "lookup 4.19 arm64",
 		Handler:     emptyHandler,
 	}, false),
 	NewBotCommand("catalog build <pullrequest> <bundle_name>", &CommandDefinition{
@@ -61,7 +61,7 @@ var supportedCommands = []BotCommand{
 	}, false),
 	NewBotCommand("workflow-launch <name> <image_or_version_or_prs> <parameters>", &CommandDefinition{
 		Description: "Launch a cluster using the requested workflow from an image or release or built PRs. The from argument may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org.",
-		Example:     "workflow-launch openshift-e2e-gcp-windows-node 4.18 gcp",
+		Example:     "workflow-launch openshift-e2e-gcp-windows-node 4.19 gcp",
 		Handler:     emptyHandler,
 	}, false),
 }
@@ -91,11 +91,11 @@ func TestMatch(t *testing.T) {
 			PropertyMap: map[string]string{},
 		},
 	}, {
-		command: "launch 4.18,openshift/installer#7160,openshift/machine-config-operator#3688 gcp,techpreview",
+		command: "launch 4.19,openshift/installer#7160,openshift/machine-config-operator#3688 gcp,techpreview",
 		match:   0,
 		properties: &Properties{
 			PropertyMap: map[string]string{
-				"image_or_version_or_prs": "4.18,openshift/installer#7160,openshift/machine-config-operator#3688",
+				"image_or_version_or_prs": "4.19,openshift/installer#7160,openshift/machine-config-operator#3688",
 				"options":                 "gcp,techpreview",
 			},
 		},
@@ -106,32 +106,32 @@ func TestMatch(t *testing.T) {
 			PropertyMap: map[string]string{},
 		},
 	}, {
-		command: "rosa create 4.18",
+		command: "rosa create 4.19",
 		match:   1,
 		properties: &Properties{
 			PropertyMap: map[string]string{
-				"version": "4.18",
+				"version": "4.19",
 			},
 		},
 	}, {
-		command: "rosa create 4.18 3h",
+		command: "rosa create 4.19 3h",
 		match:   1,
 		properties: &Properties{
 			PropertyMap: map[string]string{
-				"version":  "4.18",
+				"version":  "4.19",
 				"duration": "3h",
 			},
 		},
 	}, {
-		command: "rosa lookup 4.18",
+		command: "rosa lookup 4.19",
 		match:   2,
 		properties: &Properties{
 			PropertyMap: map[string]string{
-				"version": "4.18",
+				"version": "4.19",
 			},
 		},
 	}, {
-		command:    "rosa launch 4.18",
+		command:    "rosa launch 4.19",
 		match:      -1,
 		properties: nil,
 	}, {
@@ -141,43 +141,43 @@ func TestMatch(t *testing.T) {
 			PropertyMap: map[string]string{},
 		},
 	}, {
-		command:       "test upgrade 4.17 4.18 aws",
+		command:       "test upgrade 4.17 4.19 aws",
 		match:         4,
 		allowMultiple: true,
 		properties: &Properties{
 			PropertyMap: map[string]string{
 				"from":    "4.17",
-				"to":      "4.18",
+				"to":      "4.19",
 				"options": "aws",
 			},
 		},
 	}, {
-		command: "test e2e 4.18 vsphere",
+		command: "test e2e 4.19 vsphere",
 		match:   5,
 		properties: &Properties{
 			PropertyMap: map[string]string{
 				"name":                    "e2e",
-				"image_or_version_or_prs": "4.18",
+				"image_or_version_or_prs": "4.19",
 				"options":                 "vsphere",
 			},
 		},
 	}, {
-		command: "test e2e 4.18 alibaba",
+		command: "test e2e 4.19 alibaba",
 		match:   5,
 		properties: &Properties{
 			PropertyMap: map[string]string{
 				"name":                    "e2e",
-				"image_or_version_or_prs": "4.18",
+				"image_or_version_or_prs": "4.19",
 				"options":                 "alibaba",
 			},
 		},
 	}, {
-		command: "test e2e 4.18 azure-stackhub",
+		command: "test e2e 4.19 azure-stackhub",
 		match:   5,
 		properties: &Properties{
 			PropertyMap: map[string]string{
 				"name":                    "e2e",
-				"image_or_version_or_prs": "4.18",
+				"image_or_version_or_prs": "4.19",
 				"options":                 "azure-stackhub",
 			},
 		},
@@ -190,11 +190,11 @@ func TestMatch(t *testing.T) {
 			},
 		},
 	}, {
-		command: "lookup 4.18 arm64",
+		command: "lookup 4.19 arm64",
 		match:   7,
 		properties: &Properties{
 			PropertyMap: map[string]string{
-				"image_or_version_or_prs": "4.18",
+				"image_or_version_or_prs": "4.19",
 				"architecture":            "arm64",
 			},
 		},
@@ -208,12 +208,12 @@ func TestMatch(t *testing.T) {
 			},
 		},
 	}, {
-		command: "workflow-launch openshift-e2e-gcp 4.18 \"BASELINE_CAPABILITY_SET=None\",\"ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI\"",
+		command: "workflow-launch openshift-e2e-gcp 4.19 \"BASELINE_CAPABILITY_SET=None\",\"ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI\"",
 		match:   9,
 		properties: &Properties{
 			PropertyMap: map[string]string{
 				"name":                    "openshift-e2e-gcp",
-				"image_or_version_or_prs": "4.18",
+				"image_or_version_or_prs": "4.19",
 				"parameters":              "\"BASELINE_CAPABILITY_SET=None\",\"ADDITIONAL_ENABLED_CAPABILITIES=CloudControllerManager CloudCredential Console Ingress MachineAPI\"",
 			},
 		},

--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -116,21 +116,21 @@ func NewBot(botToken, botSigningSecret string, graceperiod time.Duration, port i
 func (b *Bot) SupportedCommands() []parser.BotCommand {
 	return []parser.BotCommand{
 		parser.NewBotCommand("launch <image_or_version_or_prs> <options>", &parser.CommandDefinition{
-			Description: fmt.Sprintf("Launch an OpenShift cluster using a known image, version, or PR(s). You may omit both arguments. Arguments can be specified as any number of comma-delimited values. Use `nightly` for the latest OCP build, `ci` for the the latest CI build, provide a version directly from any listed on https://amd64.ocp.releases.ci.openshift.org, a stream name (4.18.0-0.ci, 4.18.0-0.nightly, etc), a major/minor `X.Y` to load the \"next stable\" version, from nightly, for that version (`4.18`), `<org>/<repo>#<pr>` to launch from any combination of PRs, or an image for the first argument. Options is a comma-delimited list of variations including platform (%s), architecture (%s), and variant (%s).",
+			Description: fmt.Sprintf("Launch an OpenShift cluster using a known image, version, or PR(s). You may omit both arguments. Arguments can be specified as any number of comma-delimited values. Use `nightly` for the latest OCP build, `ci` for the the latest CI build, provide a version directly from any listed on https://amd64.ocp.releases.ci.openshift.org, a stream name (4.19.0-0.ci, 4.19.0-0.nightly, etc), a major/minor `X.Y` to load the \"next stable\" version, from nightly, for that version (`4.19`), `<org>/<repo>#<pr>` to launch from any combination of PRs, or an image for the first argument. Options is a comma-delimited list of variations including platform (%s), architecture (%s), and variant (%s).",
 				strings.Join(CodeSlice(manager.SupportedPlatforms), ", "),
 				strings.Join(CodeSlice(manager.SupportedArchitectures), ", "),
 				strings.Join(CodeSlice(manager.SupportedParameters), ", ")),
-			Example: "launch 4.18,openshift/installer#7160,openshift/machine-config-operator#3688 gcp,techpreview",
+			Example: "launch 4.19,openshift/installer#7160,openshift/machine-config-operator#3688 gcp,techpreview",
 			Handler: LaunchCluster,
 		}, false),
 		parser.NewBotCommand("rosa create <version> <duration>", &parser.CommandDefinition{
 			Description: "Launch an cluster in ROSA. Only GA Openshift versions are supported at the moment.",
-			Example:     "rosa create 4.18 3h",
+			Example:     "rosa create 4.19 3h",
 			Handler:     RosaCreate,
 		}, false),
 		parser.NewBotCommand("rosa lookup <version>", &parser.CommandDefinition{
 			Description: "Find openshift version(s) with provided prefix that is supported in ROSA.",
-			Example:     "rosa lookup 4.18",
+			Example:     "rosa lookup 4.19",
 			Handler:     RosaLookup,
 		}, false),
 		parser.NewBotCommand("rosa describe <cluster>", &parser.CommandDefinition{
@@ -156,12 +156,12 @@ func (b *Bot) SupportedCommands() []parser.BotCommand {
 		}, false),
 		parser.NewBotCommand("test upgrade <from> <to> <options>", &parser.CommandDefinition{
 			Description: fmt.Sprintf("Run the upgrade tests between two release images. The arguments may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org. You may change the upgrade test by passing `test=NAME` in options with one of %s", strings.Join(CodeSlice(manager.SupportedUpgradeTests), ", ")),
-			Example:     "test upgrade 4.17 4.18 aws",
+			Example:     "test upgrade 4.17 4.19 aws",
 			Handler:     TestUpgrade,
 		}, false),
 		parser.NewBotCommand("test <name> <image_or_version_or_prs> <options>", &parser.CommandDefinition{
 			Description: fmt.Sprintf("Run the requested test suite from an image or release or built PRs. Supported test suites are %s. The from argument may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org. ", strings.Join(CodeSlice(manager.SupportedTests), ", ")),
-			Example:     "test e2e 4.18 vsphere",
+			Example:     "test e2e 4.19 vsphere",
 			Handler:     Test,
 		}, false),
 		parser.NewBotCommand("build <pullrequest>", &parser.CommandDefinition{
@@ -171,17 +171,17 @@ func (b *Bot) SupportedCommands() []parser.BotCommand {
 		}, false),
 		parser.NewBotCommand("workflow-launch <name> <image_or_version_or_prs> <parameters>", &parser.CommandDefinition{
 			Description: "Launch a cluster using the requested workflow from an image or release or built PRs. The from argument may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org.",
-			Example:     "workflow-launch openshift-e2e-gcp-windows-node 4.18 gcp",
+			Example:     "workflow-launch openshift-e2e-gcp-windows-node 4.19 gcp",
 			Handler:     WorkflowLaunch,
 		}, false),
 		parser.NewBotCommand("workflow-test <name> <image_or_version_or_prs> <parameters>", &parser.CommandDefinition{
 			Description: "Start the test using the requested workflow from an image or release or built PRs. The from argument may be a pull spec of a release image or tags from https://amd64.ocp.releases.ci.openshift.org.",
-			Example:     "workflow-test openshift-e2e-gcp 4.18",
+			Example:     "workflow-test openshift-e2e-gcp 4.19",
 			Handler:     WorkflowTest,
 		}, false),
 		parser.NewBotCommand("workflow-upgrade <name> <from_image_or_version_or_prs> <to_image_or_version_or_prs> <parameters>", &parser.CommandDefinition{
 			Description: "Run a custom upgrade using the requested workflow from an image or release or built PRs to a specified version/image/pr from https://amd64.ocp.releases.ci.openshift.org. ",
-			Example:     "workflow-upgrade openshift-upgrade-azure-ovn 4.17 4.18 azure",
+			Example:     "workflow-upgrade openshift-upgrade-azure-ovn 4.17 4.19 azure",
 			Handler:     WorkflowUpgrade,
 		}, false),
 		parser.NewBotCommand("version", &parser.CommandDefinition{
@@ -190,7 +190,7 @@ func (b *Bot) SupportedCommands() []parser.BotCommand {
 		}, false),
 		parser.NewBotCommand("lookup <image_or_version_or_prs> <architecture>", &parser.CommandDefinition{
 			Description: "Get info about a version.",
-			Example:     "lookup 4.18 arm64",
+			Example:     "lookup 4.19 arm64",
 			Handler:     Lookup,
 		}, false),
 		parser.NewBotCommand("catalog build <pullrequest> <bundle_name>", &parser.CommandDefinition{


### PR DESCRIPTION
Since Openshift 4.18 went GA, we are updating clusterbot's default version for Openshift.