### PR TITLE
Fix for PR builds

### DIFF
--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -1551,7 +1551,7 @@ const permissionsScript = `
 # prow doesn't allow init containers or a second container
 export PATH=$PATH:/tmp/bin
 mkdir /tmp/bin
-curl -sL https://mirror.openshift.com/pub/openshift-v4/$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/clients/ocp/4.18.0/openshift-client-linux.tar.gz | tar xvzf - -C /tmp/bin/ oc
+curl -sL https://mirror.openshift.com/pub/openshift-v4/$(uname -m | sed 's/aarch64/arm64/;s/x86_64/amd64/')/clients/ocp/4.18.1/openshift-client-linux.tar.gz | tar xvzf - -C /tmp/bin/ oc
 chmod ug+x /tmp/bin/oc
 
 # grant all authenticated users access to the images in this namespace


### PR DESCRIPTION
The `4.18` GA was released as version `4.18.1` and not `4.18.0`.  So, when we went to look for the `oc` that we typically use, it was missing and causing all `build` operations to fail. 
Like:
 https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1895111408249475072
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1895073228456464384
This PR adjusts the client pull to utilize `4.18.1`.