### PR TITLE
OCPCRT-367,OCPCRT-368,OCPCRT-370: MCE Improvements

### DIFF
--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -161,7 +161,7 @@ type LeaseClient interface {
 }
 
 type jobManager struct {
-	lock                 sync.Mutex
+	lock                 sync.RWMutex
 	requests             map[string]*JobRequest
 	jobs                 map[string]*Job
 	started              time.Time

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -27,6 +27,7 @@ const ChannelTag = "ci-chat-bot/channel"
 const ExpiryTimeTag = "ci-chat-bot/expiry-time"
 const RequestTimeTag = "ci-chat-bot/request-time"
 const CustomImageTag = "ci-chat-bot/custom-image"
+const UserNotifiedTag = "ci-chat-bot/user-notified"
 
 type BuildClusterClientConfig struct {
 	CoreConfig        *rest.Config


### PR DESCRIPTION
This PR makes improvements to 3 areas of the MCE support:
- removes unnecessary empty message when calling `mce auth`
- removes requirement of cluster name for `auth` and `delete` commands when user only has 1 active cluster
- adds an annotation to the managed cluster after a user is notified to prevent extra notifications after the first

Depends on https://github.com/openshift/continuous-release-jobs/pull/1574