### PR TITLE
OCPCRT-369: manager: improve mce create and mce list

### DIFF
--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -161,7 +161,7 @@ type LeaseClient interface {
 }
 
 type jobManager struct {
-	lock                 sync.Mutex
+	lock                 sync.RWMutex
 	requests             map[string]*JobRequest
 	jobs                 map[string]*Job
 	started              time.Time


### PR DESCRIPTION
Adds defaulting for version, duration, and platform. This significantly improves the error message when an invalid value is received and allows shorter creation requests such as `mce create`, `mce create 4.19`, or `mce create 4.19 8h`.  As a result, the output has been improved to also display the version, platform, and duration in the creation response message.

The `mce list` function also now displays the platform and version in its output.