### PR TITLE
Rosa v1.2.51 bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -293,7 +293,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/openshift/rosa v1.2.50
+	github.com/openshift/rosa v1.2.51
 	github.com/operator-framework/api v0.17.6
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2527,8 +2527,8 @@ github.com/openshift/moby-moby v1.4.2-0.20190308215630-da810a85109d h1:1LuQzDKgi
 github.com/openshift/moby-moby v1.4.2-0.20190308215630-da810a85109d/go.mod h1:LJM49W8fBVSj+rvcopJZu9mgH5Tx6HwLHySIYeGeu4k=
 github.com/openshift/oc v0.0.0-alpha.0.0.20230410203846-b68ac7c39057 h1:qPCovANfcKaI45rXB/TcIgoaJtufe/W9LcCBc5PaXVM=
 github.com/openshift/oc v0.0.0-alpha.0.0.20230410203846-b68ac7c39057/go.mod h1:XpOVZsTmYlQz/ndFR/FOfPLm4/k13XMafwYNkfA8wLc=
-github.com/openshift/rosa v1.2.50 h1:bMv/xyK3YMFgnnyBkRiZSTx4xiLj9d38tl1iLF1tCEY=
-github.com/openshift/rosa v1.2.50/go.mod h1:/I810LVMk96epuDBARqbF81EtHOrE8WF1dKuzlbBnJA=
+github.com/openshift/rosa v1.2.51 h1:LgrVDL7kHCtWaUHJWT5R90CSQJeuFpvoAyfYYxhTt+k=
+github.com/openshift/rosa v1.2.51/go.mod h1:/I810LVMk96epuDBARqbF81EtHOrE8WF1dKuzlbBnJA=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/operator-framework/api v0.17.6 h1:E6+vlvYUKafvoXYtCuHlDZrXX4vl8AT+r93OxNlzjpU=
 github.com/operator-framework/api v0.17.6/go.mod h1:l/cuwtPxkVUY7fzYgdust2m9tlmb8I4pOvbsUufRb24=

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/openshift/centos:stream9
 LABEL maintainer="apavel@redhat.com"
 ADD ci-chat-bot /usr/bin/ci-chat-bot
-RUN curl -s -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/1.2.50/rosa-linux.tar.gz | tar -xvz -C /usr/bin --no-same-owner
+RUN curl -s -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/1.2.51/rosa-linux.tar.gz | tar -xvz -C /usr/bin --no-same-owner
 ENTRYPOINT ["/usr/bin/ci-chat-bot"]

--- a/vendor/github.com/openshift/rosa/pkg/info/info.go
+++ b/vendor/github.com/openshift/rosa/pkg/info/info.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package info
 
-const DefaultVersion = "1.2.50"
+const DefaultVersion = "1.2.51"
 
 // Build contains the short Git SHA of the CLI at the point it was build. Set via `-ldflags` at build time
 var Build = "local"

--- a/vendor/github.com/openshift/rosa/pkg/ocm/clusters.go
+++ b/vendor/github.com/openshift/rosa/pkg/ocm/clusters.go
@@ -630,14 +630,14 @@ func (c *Client) UpdateCluster(clusterKey string, creator *aws.Creator, config S
 		if len(config.OvnInternalSubnetConfiguration) > 0 {
 			// Create a builder for the specific migration type's configuration if necessary
 			sdnToOvnBuilder := &v1.SdnToOvnClusterMigrationBuilder{}
-			if _, ok := config.OvnInternalSubnetConfiguration[JoinIpv4]; ok {
-				sdnToOvnBuilder.JoinIpv4(config.OvnInternalSubnetConfiguration[JoinIpv4])
+			if _, ok := config.OvnInternalSubnetConfiguration[SubnetConfigJoin]; ok {
+				sdnToOvnBuilder.JoinIpv4(config.OvnInternalSubnetConfiguration[SubnetConfigJoin])
 			}
-			if _, ok := config.OvnInternalSubnetConfiguration[TransitIpv4]; ok {
-				sdnToOvnBuilder.TransitIpv4(config.OvnInternalSubnetConfiguration[TransitIpv4])
+			if _, ok := config.OvnInternalSubnetConfiguration[SubnetConfigTransit]; ok {
+				sdnToOvnBuilder.TransitIpv4(config.OvnInternalSubnetConfiguration[SubnetConfigTransit])
 			}
-			if _, ok := config.OvnInternalSubnetConfiguration[MasqueradeIpv4]; ok {
-				sdnToOvnBuilder.MasqueradeIpv4(config.OvnInternalSubnetConfiguration[MasqueradeIpv4])
+			if _, ok := config.OvnInternalSubnetConfiguration[SubnetConfigMasquerade]; ok {
+				sdnToOvnBuilder.MasqueradeIpv4(config.OvnInternalSubnetConfiguration[SubnetConfigMasquerade])
 			}
 			requestBuilder.SdnToOvn(sdnToOvnBuilder)
 		}

--- a/vendor/github.com/openshift/rosa/pkg/ocm/migrations.go
+++ b/vendor/github.com/openshift/rosa/pkg/ocm/migrations.go
@@ -9,10 +9,6 @@ import (
 )
 
 const (
-	TransitIpv4    = "transit_ipv4"
-	JoinIpv4       = "join_ipv4"
-	MasqueradeIpv4 = "masquerade_ipv4"
-
 	SubnetConfigTransit    = "transit"
 	SubnetConfigMasquerade = "masquerade"
 	SubnetConfigJoin       = "join"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1132,7 +1132,7 @@ github.com/openshift/library-go/pkg/oauth/oauthdiscovery
 github.com/openshift/oc/pkg/helpers/term
 github.com/openshift/oc/pkg/helpers/tokencmd
 github.com/openshift/oc/pkg/version
-# github.com/openshift/rosa v1.2.50
+# github.com/openshift/rosa v1.2.51
 ## explicit; go 1.21
 github.com/openshift/rosa/assets
 github.com/openshift/rosa/pkg/arguments


### PR DESCRIPTION
Using `rosa create 4.18.1 2h` in a slack app connected to a running version of ci-chat-bot using this branch, I see the ROSA cluster getting created.