### PR TITLE
Skip processing the "default" security group

### DIFF
--- a/hack/rosa-cleanup.py
+++ b/hack/rosa-cleanup.py
@@ -260,6 +260,8 @@ def prune_ec2_security_groups(clusters, resources):
 
     security_groups = []
     for security_group in resources:
+        if security_group['GroupName'] == "default":
+            continue
         if 'Tags' in security_group:
             if not associated_with_active_cluster(security_group['Tags'], clusters):
                 security_groups.append(ec2.SecurityGroup(security_group["GroupId"]))


### PR DESCRIPTION
Recent changes went into effect, from PGE, for resource tagging.  These changes added tags to resources that previously didn't have them (like the `default` security group).  This caused the `rosa-cleanup.py` script to fail when attempting to delete the `default` security group (because it did not have the ROSA specific tags we look for to prune resources).

This PR updates the `rosa-cleanup.py` script to explicitly skip the `default` security group.