### PR TITLE
Bump the Max ROSA Age up to 8 hours

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -171,7 +171,7 @@ func NewJobManager(
 		hiveConfigMapClient:      hiveConfigMapClient,
 		rosaSecretClient:         rosaSecretClient,
 		rClient:                  rosaClient,
-		maxRosaAge:               6 * time.Hour,
+		maxRosaAge:               8 * time.Hour,
 		defaultRosaAge:           6 * time.Hour,
 		rosaSubnets:              rosaSubnetList,
 		rosaClusterLimit:         rosaClusterLimit,


### PR DESCRIPTION
Using a ClusterBot ROSA cluster for a day can get frustrating when the cluster is torn down towards the end of the day. Bump up the Max age so that it is more likely to span the length of an entire working day. Leave the default as is so that this change is less likely to suddenly impact the overall resource usage footprint of clusterbot.