### PR TITLE
manager: add launch label to custom imagesets

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -199,7 +199,7 @@ func (m *jobManager) updateImageSetList() error {
 	m.mceClusters.lock.RLock()
 	for _, imageset := range imagesetList.Items {
 		// clean up orphaned imagesets; wait until managed cluster list is not empty to avoid deleting in-use imagesets on restart
-		if len(m.mceClusters.clusters) > 0 && strings.HasPrefix(imageset.Name, "chat-bot") {
+		if len(m.mceClusters.clusters) > 0 && imageset.Labels[utils.LaunchLabel] == "true" {
 			if _, ok := m.mceClusters.clusters[imageset.Name]; !ok {
 				if err := m.dpcrHiveClient.Delete(context.TODO(), &imageset); err != nil {
 					metrics.RecordError(errorMCECleanupImagesets, m.errorMetric)

--- a/pkg/manager/mce.go
+++ b/pkg/manager/mce.go
@@ -418,6 +418,9 @@ func (m *jobManager) createCustomImageset(releaseURL, imagesetName string) error
 	imageset := hivev1.ClusterImageSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: imagesetName,
+			Labels: map[string]string{
+				utils.LaunchLabel: "true",
+			},
 		},
 		Spec: hivev1.ClusterImageSetSpec{
 			ReleaseImage: releaseURL,


### PR DESCRIPTION
When multiple cluster bots are running, they will delete each others imagesets. This PR adds the LaunchLabel to the imagesets so the Cluster Bot can identify which imagesets it owns.