### PR TITLE
prow: remove gcp-2 cluster profile ConfigMap

### DIFF
--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -1701,7 +1701,7 @@ func (e *resolvedEnvironment) Lookup(name string) string {
 	return ""
 }
 
-func convertToAccount2(job *prowapiv1.ProwJob, sourceConfig *citools.ReleaseBuildConfiguration, profileName, profileSecret, profileConfigMap, accountDomain string) error {
+func convertToAccount2(job *prowapiv1.ProwJob, sourceConfig *citools.ReleaseBuildConfiguration, profileName, profileSecret, accountDomain string) error {
 	job.Annotations["ci-operator.openshift.io/cloud-cluster-profile"] = profileName
 	for index, volume := range job.Spec.PodSpec.Volumes {
 		if volume.Name == "cluster-profile" {
@@ -1709,10 +1709,6 @@ func convertToAccount2(job *prowapiv1.ProwJob, sourceConfig *citools.ReleaseBuil
 				volume.Projected = &corev1.ProjectedVolumeSource{}
 			}
 			volume.Projected.Sources = []corev1.VolumeProjection{{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: profileSecret}}}}
-			// gcp-2 has both a secret and a configmap for some reason...
-			if profileConfigMap != "" {
-				volume.Projected.Sources = append(volume.Projected.Sources, corev1.VolumeProjection{ConfigMap: &corev1.ConfigMapProjection{LocalObjectReference: corev1.LocalObjectReference{Name: profileConfigMap}}})
-			}
 			job.Spec.PodSpec.Volumes[index] = volume
 		}
 	}
@@ -1737,13 +1733,13 @@ func convertToAccount2(job *prowapiv1.ProwJob, sourceConfig *citools.ReleaseBuil
 }
 
 func convertAWSToAWS2(job *prowapiv1.ProwJob, sourceConfig *citools.ReleaseBuildConfiguration) error {
-	return convertToAccount2(job, sourceConfig, "aws-2", "cluster-secrets-aws-2", "", "aws-2.ci.openshift.org")
+	return convertToAccount2(job, sourceConfig, "aws-2", "cluster-secrets-aws-2", "aws-2.ci.openshift.org")
 }
 
 func convertAzureToAzure2(job *prowapiv1.ProwJob, sourceConfig *citools.ReleaseBuildConfiguration) error {
-	return convertToAccount2(job, sourceConfig, "azure-2", "cluster-secrets-azure-2", "", "ci2.azure.devcluster.openshift.com")
+	return convertToAccount2(job, sourceConfig, "azure-2", "cluster-secrets-azure-2", "ci2.azure.devcluster.openshift.com")
 }
 
 func convertGCPToGCP2(job *prowapiv1.ProwJob, sourceConfig *citools.ReleaseBuildConfiguration) error {
-	return convertToAccount2(job, sourceConfig, "gcp-openshift-gce-devel-ci-2", "cluster-secrets-gcp-openshift-gce-devel-ci-2", "cluster-profile-gcp-openshift-gce-devel-ci-2", "")
+	return convertToAccount2(job, sourceConfig, "gcp-openshift-gce-devel-ci-2", "cluster-secrets-gcp-openshift-gce-devel-ci-2", "")
 }


### PR DESCRIPTION
`ConfigMap` for `gcp-2` has been removed by https://github.com/openshift/release/pull/58820, @psalajova will possibly prove me wrong.
We have also hit this issue https://issues.redhat.com/browse/DPTP-4563