### PR TITLE
Correct help message for build command

### DIFF
--- a/pkg/slack/events/messages/message_handler.go
+++ b/pkg/slack/events/messages/message_handler.go
@@ -163,7 +163,7 @@ func GenerateHelpOverviewMessage(allowPrivate bool) string {
 	helpMessage += "• `workflow-upgrade <name> <from> <to> <parameters>` - Custom upgrade workflows\n"
 
 	helpMessage += "\n*Building:*\n"
-	helpMessage += "• `build <pullrequest>` - Create release image from PRs (preserved 12h)\n"
+	helpMessage += "• `build <pullrequest>` - Create release image from PRs (preserved 1 week)\n"
 	helpMessage += "• `catalog build <pullrequest> <bundle_name>` - Create operator catalog from PR\n"
 
 	helpMessage += "\n*Information:*\n"


### PR DESCRIPTION
The current message incorrectly states that custom built release images are available for 12 hours.  They are actually preserved for 1 week.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED