### PR TITLE
manager: support quay-proxy.ci.openshift.org release payloads

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -2020,6 +2020,10 @@ var validVersionRegexes = []*regexp.Regexp{
 
 	// Releases built with clusterbot 'build' command
 	regexp.MustCompile(`^registry\.build.*\.ci\.openshift\.org/ci.*/release`),
+
+	// Quay-proxy releases
+	// quay-proxy.ci.openshift.org/openshift/ci:rc_payload__5.0.0-0.ci-quay-2026-05-04-204309
+	regexp.MustCompile(`^quay-proxy\.ci\.openshift\.org/openshift/ci:rc_payload__\d+\.\d+\.\d+-0\.(ci|nightly)(-quay)?-\d{4}-\d{2}-\d{2}-\d{6}$`),
 }
 
 // containsValidVersion checks if the provided list of images, versions, or PRs contains a valid version.

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -257,6 +257,27 @@ func Test_containsValidVersion(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "Quay-proxy ci-quay release: 'launch quay-proxy.ci.openshift.org/openshift/ci:rc_payload__5.0.0-0.ci-quay-2026-05-04-204309'",
+			args: args{
+				listOfImageOrVersionOrPRs: []string{"quay-proxy.ci.openshift.org/openshift/ci:rc_payload__5.0.0-0.ci-quay-2026-05-04-204309"},
+			},
+			want: true,
+		},
+		{
+			name: "Quay-proxy ci-quay release with PR: 'launch openshift/installer#7160,quay-proxy.ci.openshift.org/openshift/ci:rc_payload__5.0.0-0.ci-quay-2026-05-04-204309'",
+			args: args{
+				listOfImageOrVersionOrPRs: []string{"openshift/installer#7160", "quay-proxy.ci.openshift.org/openshift/ci:rc_payload__5.0.0-0.ci-quay-2026-05-04-204309"},
+			},
+			want: true,
+		},
+		{
+			name: "Quay-proxy ci release without -quay: 'launch quay-proxy.ci.openshift.org/openshift/ci:rc_payload__5.0.0-0.ci-2026-05-04-204309'",
+			args: args{
+				listOfImageOrVersionOrPRs: []string{"quay-proxy.ci.openshift.org/openshift/ci:rc_payload__5.0.0-0.ci-2026-05-04-204309"},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Add validation regex for rc_payload images served through the quay proxy so users can launch clusters from these releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended version validation to recognize additional OpenShift release references from continuous integration sources
  * Improves job request handling by preventing false rejections of valid release reference formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->