### PR TITLE
manager: fix reference release and pullspec launches

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1246,6 +1246,13 @@ func buildPullSpec(namespace, tagName, isName string) string {
 	return fmt.Sprintf("registry.ci.openshift.org/%s/%s%s%s", namespace, isName, delimiter, tagName)
 }
 
+func pullSpecForTagRef(tag *imagev1.TagReference, namespace, isName string) string {
+	if tag.Reference && tag.From != nil && tag.From.Kind == "DockerImage" && tag.From.Name != "" {
+		return tag.From.Name
+	}
+	return buildPullSpec(namespace, tag.Name, isName)
+}
+
 // ResolveImageOrVersion returns installSpec, tag name or version, runSpec, and error
 func (m *jobManager) ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion, architecture string) (string, string, string, error) {
 	if len(strings.TrimSpace(imageOrVersion)) == 0 {
@@ -1325,37 +1332,37 @@ func (m *jobManager) ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 		if m := reMajorMinorVersion.FindStringSubmatch(unresolved); m != nil {
 			if tag := findNewestImageSpecTagWithStream(is, fmt.Sprintf("%s.0-0.nightly%s", unresolved, archSuffix)); tag != nil {
 				klog.Infof("Resolved major.minor %s to nightly tag %s", imageOrVersion, tag.Name)
-				installSpec := buildPullSpec(ns, tag.Name, isName)
+				installSpec := pullSpecForTagRef(tag, ns, isName)
 				runSpec := ""
 				if architecture == "amd64" || architecture == "multi" {
 					runSpec = installSpec
 				} else {
 					runTag := findNewestImageSpecTagWithStream(amd64IS, fmt.Sprintf("%s.0-0.nightly", unresolved))
-					runSpec = buildPullSpec("ocp", runTag.Name, "release")
+					runSpec = pullSpecForTagRef(runTag, "ocp", "release")
 				}
 				return installSpec, tag.Name, runSpec, nil
 			}
 			if tag := findNewestImageSpecTagWithStream(is, fmt.Sprintf("%s.0-0.ci%s", unresolved, archSuffix)); tag != nil {
 				klog.Infof("Resolved major.minor %s to ci tag %s", imageOrVersion, tag.Name)
-				installSpec := buildPullSpec(ns, tag.Name, isName)
+				installSpec := pullSpecForTagRef(tag, ns, isName)
 				runSpec := ""
 				if architecture == "amd64" || architecture == "multi" {
 					runSpec = installSpec
 				} else {
 					runTag := findNewestImageSpecTagWithStream(amd64IS, fmt.Sprintf("%s.0-0.ci", unresolved))
-					runSpec = buildPullSpec("ocp", runTag.Name, "release")
+					runSpec = pullSpecForTagRef(runTag, "ocp", "release")
 				}
 				return installSpec, tag.Name, runSpec, nil
 			}
 			if tag := findNewestStableImageSpecTagBySemanticMajor(is, unresolved, architecture); tag != nil {
 				klog.Infof("Resolved major.minor %s to semver tag %s", imageOrVersion, tag.Name)
-				installSpec := buildPullSpec(ns, tag.Name, isName)
+				installSpec := pullSpecForTagRef(tag, ns, isName)
 				runSpec := ""
 				if architecture == "amd64" || architecture == "multi" {
 					runSpec = installSpec
 				} else {
 					runTag := findNewestImageSpecTagWithStream(amd64IS, unresolved)
-					runSpec = buildPullSpec("ocp", runTag.Name, "release")
+					runSpec = pullSpecForTagRef(runTag, "ocp", "release")
 				}
 				return installSpec, tag.Name, runSpec, nil
 			}
@@ -1384,7 +1391,7 @@ func (m *jobManager) ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 						return "", "", "", fmt.Errorf("failed to identify semver for image %s: %w", tag.Image, err)
 					}
 					runTag := findNewestImageSpecTagWithStream(amd64IS, fmt.Sprintf("%d.%d.0-0.nightly", ver.Major, ver.Minor))
-					runSpec = buildPullSpec("ocp", runTag.Name, "release")
+					runSpec = pullSpecForTagRef(runTag, "ocp", "release")
 				} else {
 					runTag, _ := findImageStatusTag(amd64IS, unresolved)
 					runSpec = buildPullSpec("ocp", runTag.Image, "release")
@@ -1396,7 +1403,7 @@ func (m *jobManager) ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 		if tag := findNewestImageSpecTagWithStream(is, unresolved); tag != nil {
 			klog.Infof("Resolved %s to tag %s", imageOrVersion, tag.Name)
 			// identify nightly stream for runspec if not amd64
-			installSpec := buildPullSpec(ns, tag.Name, isName)
+			installSpec := pullSpecForTagRef(tag, ns, isName)
 			runSpec := ""
 			if architecture == "amd64" || architecture == "multi" {
 				runSpec = installSpec
@@ -1409,10 +1416,26 @@ func (m *jobManager) ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 						return "", "", "", fmt.Errorf("failed to identify semver for image %s: %w", tag.Name, err)
 					}
 					runTag := findNewestImageSpecTagWithStream(amd64IS, fmt.Sprintf("%d.%d.0-0.nightly", ver.Major, ver.Minor))
-					runSpec = buildPullSpec("ocp", runTag.Name, "release")
+					runSpec = pullSpecForTagRef(runTag, "ocp", "release")
 				} else {
 					runTag := findNewestImageSpecTagWithStream(amd64IS, unresolved)
-					runSpec = buildPullSpec("ocp", runTag.Name, "release")
+					runSpec = pullSpecForTagRef(runTag, "ocp", "release")
+				}
+			}
+			return installSpec, tag.Name, runSpec, nil
+		}
+
+		if tag := findSpecTagByName(is, unresolved); tag != nil {
+			klog.Infof("Resolved %s to spec tag %s", imageOrVersion, tag.Name)
+			installSpec := pullSpecForTagRef(tag, ns, isName)
+			runSpec := ""
+			if architecture == "amd64" || architecture == "multi" {
+				runSpec = installSpec
+			} else {
+				if runTag := findSpecTagByName(amd64IS, unresolved); runTag != nil {
+					runSpec = pullSpecForTagRef(runTag, "ocp", "release")
+				} else {
+					runSpec = installSpec
 				}
 			}
 			return installSpec, tag.Name, runSpec, nil
@@ -1492,6 +1515,15 @@ func findImageStatusTag(is *imagev1.ImageStream, name string) (*imagev1.TagEvent
 		}
 	}
 	return nil, ""
+}
+
+func findSpecTagByName(is *imagev1.ImageStream, name string) *imagev1.TagReference {
+	for i := range is.Spec.Tags {
+		if is.Spec.Tags[i].Name == name {
+			return &is.Spec.Tags[i]
+		}
+	}
+	return nil
 }
 
 func (m *jobManager) GetWorkflowConfig() *WorkflowConfig {

--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -380,6 +380,11 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 			targetRelease = m[1]
 		}
 	}
+	// make sure a reasonable current release is set as BRANCH to avoid issues with
+	// the BRANCH defined in the prowjob being too old
+	if len(targetRelease) == 0 {
+		targetRelease = fmt.Sprintf("%d.%d", CurrentRelease.Major, CurrentRelease.Minor)
+	}
 
 	// Identify the images to be placed in RELEASE_IMAGE_INITIAL and RELEASE_IMAGE_LATEST,
 	// depending on whether this is an upgrade job or not. Create env var definitions for


### PR DESCRIPTION
Update the pullspec generation code to seamlessly handle both local registry and reference based releases. For reference-based release, we use `tagReference.From.Name` and local releases fall back to the old method. It also adds a if section to the image/version resolver to handle discovery of release images without a status tag (i.e. reference-based release tags) by looping through spec tags instead of status tags.

This also now defaults the `BRANCH` in the default prowjobs to the version in `CurrentRelease` if the version cannot be automatically detected (like when specifying a full pullspec URL). The current `amd64` prowjob specifies `4.9` as the default `BRANCH`, which simply doesn't exist anymore, breaking all launch attempts that use a full URL pullspec. By manually overriding it, it shouldn't matter what the prowjob defaults the `BRANCH` to anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image resolution so the correct image source is selected when tags reference other images.
  * Ensure job release target defaults to the current major.minor release when no usable version is detected, preventing empty/incorrect job targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->