### PR TITLE
manager: persist MCE custom version as annotation to survive job expiry

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -2599,8 +2599,26 @@ func (m *jobManager) CreateMceCluster(user, channel, platform string, from [][]s
 	return msg, nil
 }
 
+func formatMCEReleaseDisplay(architecture string, jobInput JobInput) string {
+	var inputParts []string
+	switch {
+	case len(jobInput.Version) > 0:
+		inputParts = append(inputParts, fmt.Sprintf("<https://%s.ocp.releases.ci.openshift.org/releasetag/%s|%s>", architecture, url.PathEscape(jobInput.Version), jobInput.Version))
+	case len(jobInput.Image) > 0:
+		inputParts = append(inputParts, "(image)")
+	}
+	for _, ref := range jobInput.Refs {
+		for _, pull := range ref.Pulls {
+			inputParts = append(inputParts, fmt.Sprintf(" <https://github.com/%s/%s/pull/%d|%s/%s#%d>", url.PathEscape(ref.Org), url.PathEscape(ref.Repo), pull.Number, ref.Org, ref.Repo, pull.Number))
+		}
+	}
+	return strings.Join(inputParts, ",")
+}
+
 func (m *jobManager) GetMceCustomVersion(cluster *clusterv1.ManagedCluster) string {
-	var version string
+	if display := cluster.Annotations[utils.RequestedReleaseDisplayTag]; display != "" {
+		return display
+	}
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	var job *Job
@@ -2611,27 +2629,16 @@ func (m *jobManager) GetMceCustomVersion(cluster *clusterv1.ManagedCluster) stri
 		}
 	}
 	if job == nil {
-		version = "unspecified version"
-	} else {
-		var jobInput JobInput
-		if len(job.Inputs) > 0 {
-			jobInput = job.Inputs[0]
-		}
-		var inputParts []string
-		switch {
-		case len(jobInput.Version) > 0:
-			inputParts = append(inputParts, fmt.Sprintf("<https://%s.ocp.releases.ci.openshift.org/releasetag/%s|%s>", job.Architecture, url.PathEscape(jobInput.Version), jobInput.Version))
-		case len(jobInput.Image) > 0:
-			inputParts = append(inputParts, "(image)")
-		}
-		for _, ref := range jobInput.Refs {
-			for _, pull := range ref.Pulls {
-				inputParts = append(inputParts, fmt.Sprintf(" <https://github.com/%s/%s/pull/%d|%s/%s#%d>", url.PathEscape(ref.Org), url.PathEscape(ref.Repo), pull.Number, ref.Org, ref.Repo, pull.Number))
-			}
-		}
-		version = strings.Join(inputParts, ",")
+		return "unspecified version"
 	}
-	return version
+	var jobInput JobInput
+	if len(job.Inputs) > 0 {
+		jobInput = job.Inputs[0]
+	}
+	if version := formatMCEReleaseDisplay(job.Architecture, jobInput); version != "" {
+		return version
+	}
+	return "unspecified version"
 }
 
 func (m *jobManager) DeleteMceCluster(user, clusterName string) (string, error) {

--- a/pkg/manager/mce.go
+++ b/pkg/manager/mce.go
@@ -254,6 +254,13 @@ func (m *jobManager) createManagedCluster(imageSet, platform, user, slackChannel
 	}
 	if req != nil {
 		managedCluster.Annotations[utils.CustomImageTag] = "true"
+		if jobInputs, _, err := m.lookupInputs(req.Inputs, req.Architecture); err != nil {
+			klog.Warningf("Failed to resolve MCE release display for cluster %s: %v", clusterName, err)
+		} else if len(jobInputs) > 0 {
+			if display := formatMCEReleaseDisplay(req.Architecture, jobInputs[0]); display != "" {
+				managedCluster.Annotations[utils.RequestedReleaseDisplayTag] = display
+			}
+		}
 	}
 
 	switch platform {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -28,6 +28,7 @@ const ExpiryTimeTag = "ci-chat-bot/expiry-time"
 const RequestTimeTag = "ci-chat-bot/request-time"
 const CustomImageTag = "ci-chat-bot/custom-image"
 const UserNotifiedTag = "ci-chat-bot/user-notified"
+const RequestedReleaseDisplayTag = "ci-chat-bot/requested-release-display"
 
 type BuildClusterClientConfig struct {
 	CoreConfig        *rest.Config


### PR DESCRIPTION
GetMceCustomVersion resolved the display string by scanning m.jobs, but completed Prow jobs are dropped ~15 minutes after completion while MCE clusters live much longer. This caused custom-image clusters to regress to "unspecified version" in listings.

Persist the formatted release display string as a ManagedCluster annotation at creation time so it survives job expiry and bot restarts. GetMceCustomVersion now checks the annotation first, falling back to the job scan for pre-existing clusters without the annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking and annotating requested release display information on managed clusters.

* **Bug Fixes**
  * Improved release version display with better error handling and fallback behavior when required data is unavailable.

* **Refactor**
  * Extracted release display string formatting logic into a dedicated reusable helper function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->