### PR TITLE
manager: resolve build promotion registry from openshift/cli spec

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1527,6 +1527,38 @@ func findSpecTagByName(is *imagev1.ImageStream, name string) *imagev1.TagReferen
 	return nil
 }
 
+func registryHostFromPullSpec(pullSpec string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(pullSpec)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse pull spec %q: %w", pullSpec, err)
+	}
+	return reference.Domain(named), nil
+}
+
+func registryHostFromStatusRepo(repo string) string {
+	if repo == "" {
+		return ""
+	}
+	return strings.SplitN(repo, "/", 2)[0]
+}
+
+// registryHostFromCLIImageStream returns the promotion registry host advertised by openshift/cli.
+// Reference-based clusters encode the remote registry on the spec cli tag; traditional clusters use status repos.
+func registryHostFromCLIImageStream(is *imagev1.ImageStream) (string, error) {
+	if tag := findSpecTagByName(is, "cli"); tag != nil {
+		if tag.Reference && tag.From != nil && tag.From.Kind == "DockerImage" && tag.From.Name != "" {
+			return registryHostFromPullSpec(tag.From.Name)
+		}
+	}
+	if host := registryHostFromStatusRepo(is.Status.PublicDockerImageRepository); host != "" {
+		return host, nil
+	}
+	if host := registryHostFromStatusRepo(is.Status.DockerImageRepository); host != "" {
+		return host, nil
+	}
+	return "", fmt.Errorf("unable to resolve registry host from openshift/cli imagestream")
+}
+
 func (m *jobManager) GetWorkflowConfig() *WorkflowConfig {
 	return m.workflowConfig
 }

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1,6 +1,139 @@
 package manager
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_registryHostFromPullSpec(t *testing.T) {
+	tests := []struct {
+		name     string
+		pullSpec string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "ci registry cli image",
+			pullSpec: "registry.ci.openshift.org/ocp/cli:4.20",
+			want:     "registry.ci.openshift.org",
+		},
+		{
+			name:     "quay proxy",
+			pullSpec: "quay-proxy.ci.openshift.org/openshift/cli:4.20",
+			want:     "quay-proxy.ci.openshift.org",
+		},
+		{
+			name:     "invalid pull spec",
+			pullSpec: "not a valid reference",
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := registryHostFromPullSpec(tt.pullSpec)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("registryHostFromPullSpec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("registryHostFromPullSpec() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_registryHostFromCLIImageStream(t *testing.T) {
+	referenceCLITag := imagev1.TagReference{
+		Name:      "cli",
+		Reference: true,
+		From: &corev1.ObjectReference{
+			Kind: "DockerImage",
+			Name: "registry.ci.openshift.org/ocp/cli:4.20",
+		},
+	}
+	quayProxyCLITag := imagev1.TagReference{
+		Name:      "cli",
+		Reference: true,
+		From: &corev1.ObjectReference{
+			Kind: "DockerImage",
+			Name: "quay-proxy.ci.openshift.org/openshift/cli:4.20",
+		},
+	}
+
+	tests := []struct {
+		name    string
+		is      *imagev1.ImageStream
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "reference cli ignores local public repo",
+			is: &imagev1.ImageStream{
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{referenceCLITag},
+				},
+				Status: imagev1.ImageStreamStatus{
+					PublicDockerImageRepository: "registry.build01.ci.openshift.org/openshift",
+				},
+			},
+			want: "registry.ci.openshift.org",
+		},
+		{
+			name: "quay proxy reference cli",
+			is: &imagev1.ImageStream{
+				Spec: imagev1.ImageStreamSpec{
+					Tags: []imagev1.TagReference{quayProxyCLITag},
+				},
+				Status: imagev1.ImageStreamStatus{
+					PublicDockerImageRepository: "registry.build01.ci.openshift.org/openshift",
+				},
+			},
+			want: "quay-proxy.ci.openshift.org",
+		},
+		{
+			name: "traditional public docker image repository",
+			is: &imagev1.ImageStream{
+				Status: imagev1.ImageStreamStatus{
+					PublicDockerImageRepository: "registry.build01.ci.openshift.org/openshift",
+				},
+			},
+			want: "registry.build01.ci.openshift.org",
+		},
+		{
+			name: "traditional docker image repository fallback",
+			is: &imagev1.ImageStream{
+				Status: imagev1.ImageStreamStatus{
+					DockerImageRepository: "registry.build02.ci.openshift.org/openshift",
+				},
+			},
+			want: "registry.build02.ci.openshift.org",
+		},
+		{
+			name:    "missing registry information",
+			is:      &imagev1.ImageStream{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := registryHostFromCLIImageStream(tt.is)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("registryHostFromCLIImageStream() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "unable to resolve registry host") {
+					t.Errorf("registryHostFromCLIImageStream() error = %v, want resolution error", err)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("registryHostFromCLIImageStream() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
 func Test_containsValidVersion(t *testing.T) {
 	type args struct {

--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -639,7 +639,10 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("unable to lookup registry URL for job")
 		}
-		registryHost := strings.SplitN(is.Status.PublicDockerImageRepository, "/", 2)[0]
+		registryHost, err := registryHostFromCLIImageStream(is)
+		if err != nil {
+			return "", fmt.Errorf("unable to lookup registry URL for job: %w", err)
+		}
 
 		// NAMESPACE must be set for this job, and be in the first position, so remove it if set
 		prow.RemoveJobEnvVar(&pj.Spec, "NAMESPACE")


### PR DESCRIPTION
Build jobs with PR refs used the cluster integrated registry from imagestream status, which is wrong for reference-based CI releases. Derive registry_host from the cli spec tag when present, matching release-controller behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced registry host resolution for pull-ref and publishing workflows with improved error handling and fallback mechanisms.

* **Tests**
  * Added comprehensive test coverage for registry host resolution across multiple image stream configuration sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->