### PR TITLE
Support version 5.0 lookups and bump to 4.23

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -100,7 +100,7 @@ const (
 
 var CurrentRelease = semver.Version{
 	Major: 4,
-	Minor: 21,
+	Minor: 23,
 }
 
 var HypershiftSupportedVersions = HypershiftSupportedVersionsType{}
@@ -1367,7 +1367,9 @@ func (m *jobManager) ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 				}
 				return installSpec, tag.Name, runSpec, nil
 			}
-			return "", "", "", fmt.Errorf("no stable, official prerelease, or nightly version published yet for %s", imageOrVersion)
+			// Now that we have more than 1 release stream (release & release-5), we need to continue processing
+			// for major.minor matches across both streams...
+			continue
 		} else if unresolved == "nightly" {
 			unresolved = fmt.Sprintf("%s.0-0.nightly%s", currentReleasePrefix, archSuffix)
 		} else if unresolved == "ci" {


### PR DESCRIPTION
User reported issue when trying to build against version `5.0`:

`build 5.0,https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/337,https://github.com/openshift/origin/pull/31124`

Bot returns with:
`no stable, official prerelease, or nightly version published yet for 5.0`

This PR changes to logic to allow searching across all release imagestreams (release and [release-5](https://redhat.atlassian.net/browse/release-5)), and also bumps the current version up to `4.23` since 4.22 has now reached GA.

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image/version resolution behavior when multiple release streams are available. The system now continues searching through available streams instead of immediately failing when a stable prerelease tag cannot be resolved.

* **Chores**
  * Updated current release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->