### PR TITLE
manager/prow: set correct delete flags for MCE

### DIFF
--- a/pkg/manager/prow.go
+++ b/pkg/manager/prow.go
@@ -909,12 +909,14 @@ func (m *jobManager) newJob(job *Job) (string, error) {
 
 		var args []string
 		for _, arg := range container.Args {
-			if strings.HasPrefix(arg, "--namespace") {
+			if strings.HasPrefix(arg, "--namespace") || strings.HasPrefix(arg, "--delete-when-idle") || strings.HasPrefix(arg, "--delete-after") {
 				continue
 			}
 			args = append(args, arg)
 		}
-		args = append(args, `--namespace=$(NAMESPACE)`)
+		// Keep the namespace around for a week like build jobs; without these flags
+		// ci-operator defaults to a 1h soft TTL and the images disappear while the MCE cluster is still up.
+		args = append(args, `--namespace=$(NAMESPACE)`, `--delete-when-idle=$(PRESERVE_DURATION)`, `--delete-after=$(DELETE_AFTER)`)
 
 		envPrefix := strings.Join(restoreImageVariableScript, " ")
 		container.Command = []string{"/bin/bash", "-c"}


### PR DESCRIPTION
Adds the `delete-when-idle` and `delete-after` flags to namespaces used by MCE clusters that do not specify a PR build. Since these were missing, the lifetime of the namespace was ~1 hour (delete-when-idle defaults to 1 hour).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom image job cleanup behavior by consistently applying the configured idle and retention durations.
  * Prevented conflicting cleanup settings from affecting job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->