### PR TITLE
OCPCRT-525: Adding support for CI Images from QCI

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1379,9 +1379,16 @@ func (m *jobManager) ResolveImageOrVersion(imageOrVersion, defaultImageOrVersion
 		}
 
 		if tag, name := findImageStatusTag(is, unresolved); tag != nil {
-			klog.Infof("Resolved %s to image %s", imageOrVersion, tag.Image)
+			// CI releases are now all references to QCI, which means they don't have a value for the "Image" field
+			var installSpec string
+			if len(tag.Image) == 0 {
+				installSpec = tag.DockerImageReference
+				klog.Infof("Resolved %s to QCI image %s", imageOrVersion, installSpec)
+			} else {
+				klog.Infof("Resolved %s to image %q", imageOrVersion, tag.Image)
+				installSpec = buildPullSpec(ns, tag.Image, isName)
+			}
 			// identify nightly stream for runspec if not amd64
-			installSpec := buildPullSpec(ns, tag.Image, isName)
 			runSpec := ""
 			if architecture == "amd64" || architecture == "multi" || strings.Contains(unresolved, "konflux") {
 				runSpec = installSpec


### PR DESCRIPTION
When users attempt to launch/build clusters from a CI release, that points to a reference release in QCI, the clusterbot is unable to resolve the `tag.Image` value because it is not set on reference releases.

Reference job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/2080191982801522688

Error message:
```
* could not run steps: step [release:latest] failed: unable to import latest release image: unable to import tag ci-ln-v40f022/release:latest at import (0): ImageStreamImport.image.openshift.io "release" is invalid: spec.images[0].from.name: Invalid value: "registry.ci.openshift.org/ocp/release-5:": invalid reference format 
```

The YAML setting that causes the error is:
```
- name: RELEASE_IMAGE_LATEST
        value: 'registry.ci.openshift.org/ocp/release-5:'
```

This PR adds a check for the empty `tag.Image` value and sets the pullSpec to the `tag.DockerImageReference` instead.

Test build/launch: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/2080278580536807424

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI image resolution for QCI-style tag events.
  * Correctly handles tag events with an empty image field by using the available Docker image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->